### PR TITLE
fix: disable occurrencesHighlight in monaco editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-studio",
-  "version": "0.2.3-beta",
+  "version": "0.2.4-beta",
   "type": "module",
   "homepage": "studio.ioflux.org",
   "repository": "https://github.com/ioflux-org/studio-json-schema",

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -195,7 +195,10 @@ const MonacoEditor = () => {
             language={schemaFormat}
             value={schemaText}
             theme={theme === "light" ? "vs-light" : "vs-dark"}
-            options={{ minimap: { enabled: false } }}
+            options={{
+              minimap: { enabled: false },
+              occurrencesHighlight: "off",
+            }}
             onChange={(value) => setSchemaText(value ?? "")}
           />
           <div className="flex-1 p-2 bg-[var(--validation-bg-color)] text-sm overflow-y-auto">


### PR DESCRIPTION
disable occurrencesHighlight in monaco editor to add proper contrast between selected and non-selected texts