### PR TITLE
feat: add file upload support for JSON/YAML schemas

### DIFF
--- a/.changeset/large-support-cake.md
+++ b/.changeset/large-support-cake.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": minor
+---
+
+feat: add file upload and global drag-and-drop support for JSON/YAML schemas

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -130,23 +130,20 @@ const MonacoEditor = () => {
   };
 
   useEffect(() => {
-    // Global dragover listener: prevents the browser (Firefox) from navigating
-    // to the dropped file URL. Must be on document, not just the editor panel.
-    const preventBrowserNav = (e: DragEvent) => e.preventDefault();
-    document.addEventListener("dragover", preventBrowserNav);
-
+    const blockBrowser = (e: DragEvent) => e.preventDefault();
+    document.addEventListener("dragover", blockBrowser);
+    document.addEventListener("drop", blockBrowser);
     return () => {
-      document.removeEventListener("dragover", preventBrowserNav);
+      document.removeEventListener("dragover", blockBrowser);
+      document.removeEventListener("drop", blockBrowser);
     };
   }, []);
 
   useEffect(() => {
     const editorEl = editorContainerRef.current;
     if (!editorEl) return;
-
-    // Scoped drop handler: only processes files dropped on the editor panel.
     const onDragOver = (e: DragEvent) => {
-      e.preventDefault();
+      e.stopPropagation();
       if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
     };
     const onDrop = (e: DragEvent) => {

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -18,7 +18,6 @@ import {
 
 import Editor, { type OnMount } from "@monaco-editor/react";
 import type { editor } from "monaco-editor";
-import defaultSchema from "../data/defaultJSONSchema.json";
 import { AppContext, type SchemaFormat } from "../contexts/AppContext";
 import SchemaVisualization from "./SchemaVisualization";
 import NavigationBar from "./NavigationBar";
@@ -28,7 +27,6 @@ import {
   getHighlightedNodeRangeFromPath,
   type JSONSchema,
 } from "../utils/parseSchema";
-import YAML from "js-yaml";
 
 type ValidationStatus = {
   status: "success" | "warning" | "error";

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -1,6 +1,7 @@
 import { useContext, useState, useEffect, useRef } from "react";
 import { BsUpload } from "react-icons/bs";
 import { Tooltip } from "react-tooltip";
+import { SESSION_SCHEMA_KEY } from "../constants";
 
 import {
   Panel,
@@ -44,7 +45,6 @@ type CreateBrowser = (
 
 const DEFAULT_SCHEMA_ID = "https://studio.ioflux.org/schema";
 const DEFAULT_SCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema";
-const SESSION_SCHEMA_KEY = "ioflux.schema.editor.content";
 const DEFAULT_EDITOR_PANEL_WIDTH = 25; // in percentage
 
 const JSON_SCHEMA_DIALECTS = [
@@ -106,7 +106,7 @@ const MonacoEditor = () => {
   );
 
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const editorContainerRef = useRef<HTMLDivElement>(null);
+
 
   const loadFile = (file: File) => {
     const reader = new FileReader();
@@ -139,30 +139,21 @@ const MonacoEditor = () => {
     };
   }, []);
 
-  useEffect(() => {
-    const editorEl = editorContainerRef.current;
-    if (!editorEl) return;
-    const onDragOver = (e: DragEvent) => {
-      e.stopPropagation();
-      if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
-    };
-    const onDrop = (e: DragEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      const file = e.dataTransfer?.files?.[0];
-      if (!file) return;
-      const ext = file.name.split(".").pop()?.toLowerCase();
-      if (!["json", "yaml", "yml"].includes(ext ?? "")) return;
-      loadFile(file);
-    };
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    e.preventDefault(); // Required to allow dropping
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+  };
 
-    editorEl.addEventListener("dragover", onDragOver);
-    editorEl.addEventListener("drop", onDrop);
-    return () => {
-      editorEl.removeEventListener("dragover", onDragOver);
-      editorEl.removeEventListener("drop", onDrop);
-    };
-  }, []);
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const file = e.dataTransfer?.files?.[0];
+    if (!file) return;
+    const ext = file.name.split(".").pop()?.toLowerCase();
+    if (!["json", "yaml", "yml"].includes(ext ?? "")) return;
+    loadFile(file);
+  };
 
   const VALIDATION_UI = getValidationUI(theme);
 
@@ -371,12 +362,13 @@ const MonacoEditor = () => {
 
   const editorPanel = (
     <Panel
-      className="flex flex-col"
+      className="flex flex-col h-full w-full relative"
       defaultSize={isMobile ? 40 : DEFAULT_EDITOR_PANEL_WIDTH}
       ref={editorPanelRef}
       collapsible
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
     >
-      <div ref={editorContainerRef} className="flex flex-col h-full w-full relative">
         <div className="flex items-center gap-2 px-2 py-1 bg-[var(--validation-bg-color)]">
           <input
             type="file"
@@ -440,7 +432,6 @@ const MonacoEditor = () => {
             {schemaValidation.message}
           </span>
         </div>
-      </div>
     </Panel>
   );
 

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -104,6 +104,8 @@ const MonacoEditor = () => {
     schemaFormat,
     changeSchemaFormat,
     selectedNode,
+    schemaText,
+    setSchemaText,
   } = useContext(AppContext);
 
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
@@ -115,14 +117,6 @@ const MonacoEditor = () => {
 
   const [compiledSchema, setCompiledSchema] = useState<CompiledSchema | null>(
     null
-  );
-
-  const initialSchemaJSON = loadSchemaJSON(SESSION_SCHEMA_KEY);
-
-  const [schemaText, setSchemaText] = useState<string>(
-    schemaFormat === "yaml"
-      ? YAML.dump(initialSchemaJSON)
-      : JSON.stringify(initialSchemaJSON, null, 2)
   );
 
   const VALIDATION_UI = getValidationUI(theme);

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -43,7 +43,6 @@ type CreateBrowser = (
 const DEFAULT_SCHEMA_ID = "https://studio.ioflux.org/schema";
 const DEFAULT_SCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema";
 const SESSION_SCHEMA_KEY = "ioflux.schema.editor.content";
-const SESSION_FORMAT_KEY = "ioflux.schema.editor.format";
 const DEFAULT_EDITOR_PANEL_WIDTH = 25; // in percentage
 
 const JSON_SCHEMA_DIALECTS = [
@@ -76,19 +75,6 @@ const getValidationUI = (theme: "light" | "dark") => ({
   },
 });
 
-const saveFormat = (key: string, format: SchemaFormat) => {
-  sessionStorage.setItem(key, format);
-};
-
-const loadSchemaJSON = (key: string): any => {
-  const raw = sessionStorage.getItem(key);
-  if (!raw) return defaultSchema;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return defaultSchema;
-  }
-};
 
 const saveSchemaJSON = (key: string, schema: JSONSchema) => {
   sessionStorage.setItem(key, JSON.stringify(schema, null, 2));
@@ -254,17 +240,6 @@ const MonacoEditor = () => {
     }
   }, [selectedNode?.id, schemaFormat, schemaText]);
 
-  useEffect(() => {
-    saveFormat(SESSION_FORMAT_KEY, schemaFormat);
-
-    const schemaJSON = loadSchemaJSON(SESSION_SCHEMA_KEY);
-
-    setSchemaText(
-      schemaFormat === "yaml"
-        ? YAML.dump(schemaJSON)
-        : JSON.stringify(schemaJSON, null, 2)
-    );
-  }, [schemaFormat]);
 
   useEffect(() => {
     if (!schemaText.trim()) return;

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -1,4 +1,6 @@
 import { useContext, useState, useEffect, useRef } from "react";
+import { BsUpload } from "react-icons/bs";
+import { Tooltip } from "react-tooltip";
 
 import {
   Panel,
@@ -102,6 +104,68 @@ const MonacoEditor = () => {
   const [compiledSchema, setCompiledSchema] = useState<CompiledSchema | null>(
     null
   );
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const editorContainerRef = useRef<HTMLDivElement>(null);
+
+  const loadFile = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const content = e.target?.result as string;
+      if (!content) return;
+      if (file.name.endsWith(".json")) {
+        changeSchemaFormat("json");
+      } else if (file.name.endsWith(".yaml") || file.name.endsWith(".yml")) {
+        changeSchemaFormat("yaml");
+      }
+      setSchemaText(content);
+    };
+    reader.readAsText(file);
+  };
+
+  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) loadFile(file);
+    event.target.value = "";
+  };
+
+  useEffect(() => {
+    // Global dragover listener: prevents the browser (Firefox) from navigating
+    // to the dropped file URL. Must be on document, not just the editor panel.
+    const preventBrowserNav = (e: DragEvent) => e.preventDefault();
+    document.addEventListener("dragover", preventBrowserNav);
+
+    return () => {
+      document.removeEventListener("dragover", preventBrowserNav);
+    };
+  }, []);
+
+  useEffect(() => {
+    const editorEl = editorContainerRef.current;
+    if (!editorEl) return;
+
+    // Scoped drop handler: only processes files dropped on the editor panel.
+    const onDragOver = (e: DragEvent) => {
+      e.preventDefault();
+      if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    };
+    const onDrop = (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const file = e.dataTransfer?.files?.[0];
+      if (!file) return;
+      const ext = file.name.split(".").pop()?.toLowerCase();
+      if (!["json", "yaml", "yml"].includes(ext ?? "")) return;
+      loadFile(file);
+    };
+
+    editorEl.addEventListener("dragover", onDragOver);
+    editorEl.addEventListener("drop", onDrop);
+    return () => {
+      editorEl.removeEventListener("dragover", onDragOver);
+      editorEl.removeEventListener("drop", onDrop);
+    };
+  }, []);
 
   const VALIDATION_UI = getValidationUI(theme);
 
@@ -315,20 +379,45 @@ const MonacoEditor = () => {
       ref={editorPanelRef}
       collapsible
     >
-      <div className="flex items-center gap-2 px-2 py-1 bg-[var(--validation-bg-color)]">
-        <label htmlFor="schema-format-select" className="sr-only">
-          Schema format
-        </label>
-        <select
-          id="schema-format-select"
-          value={schemaFormat}
-          onChange={(e) => changeSchemaFormat(e.target.value as SchemaFormat)}
-          className="ml-auto flex-shrink-0 bg-[var(--bg-color)] text-[var(--text-color)] text-sm outline-none cursor-pointer border border-[var(--popup-border-color)] rounded-sm"
-        >
-          <option value="json">JSON</option>
-          <option value="yaml">YAML</option>
-        </select>
-      </div>
+      <div ref={editorContainerRef} className="flex flex-col h-full w-full relative">
+        <div className="flex items-center gap-2 px-2 py-1 bg-[var(--validation-bg-color)]">
+          <input
+            type="file"
+            id="schema-file-input"
+            ref={fileInputRef}
+            onChange={handleFileUpload}
+            accept=".json,.yaml,.yml"
+            className="hidden"
+          />
+          <div className="ml-auto flex items-center gap-3">
+            <button
+              className="text-lg cursor-pointer"
+              onClick={() => fileInputRef.current?.click()}
+              data-tooltip-id="upload-file-editor"
+              aria-label="Upload JSON/YAML schema file"
+              title="Upload JSON/YAML schema file"
+            >
+              <BsUpload className="text-[var(--text-color)]" />
+            </button>
+            <Tooltip
+              id="upload-file-editor"
+              content="Upload JSON/YAML (or drag & drop)"
+              style={{ fontSize: "10px", zIndex: 100 }}
+            />
+            <label htmlFor="schema-format-select" className="sr-only">
+              Schema format
+            </label>
+            <select
+              id="schema-format-select"
+              value={schemaFormat}
+              onChange={(e) => changeSchemaFormat(e.target.value as SchemaFormat)}
+              className="flex-shrink-0 bg-[var(--bg-color)] text-[var(--text-color)] text-sm outline-none cursor-pointer border border-[var(--popup-border-color)] rounded-sm"
+            >
+              <option value="json">JSON</option>
+              <option value="yaml">YAML</option>
+            </select>
+          </div>
+        </div>
       <div className="flex-1 min-h-0">
         <Editor
           height="100%"
@@ -351,8 +440,9 @@ const MonacoEditor = () => {
         className="shrink-0 px-2 py-1.5 bg-[var(--validation-bg-color)] text-sm"
       >
         <span className={VALIDATION_UI[schemaValidation.status].className}>
-          {schemaValidation.message}
-        </span>
+            {schemaValidation.message}
+          </span>
+        </div>
       </div>
     </Panel>
   );

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -1,4 +1,4 @@
-import { BsGithub, BsMoonStars, BsBook, BsSun } from "react-icons/bs";
+import { BsGithub, BsMoonStars, BsBook, BsSun, BsUpload } from "react-icons/bs";
 import { RiSearchLine, RiCloseLine } from "react-icons/ri";
 import {
   type KeyboardEvent,
@@ -11,20 +11,70 @@ import {
 import { Tooltip } from "react-tooltip";
 import { AppContext } from "../contexts/AppContext";
 import FullscreenToggleButton from "./FullscreenToggleButton";
+import type { SchemaFormat } from "../contexts/AppContext";
 
 const NavigationBar = () => {
   const {
     theme,
     toggleTheme,
     isFullScreen,
+    schemaFormat,
+    changeSchemaFormat,
+    setSchemaText,
     searchString,
     setSearchString,
     setSelectedNode,
     triggerNavigateMatch,
   } = useContext(AppContext);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const mobileSearchInputRef = useRef<HTMLInputElement>(null);
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
+
+  const loadFile = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const content = e.target?.result as string;
+      if (!content) return;
+      if (file.name.endsWith(".json")) {
+        changeSchemaFormat("json");
+      } else if (file.name.endsWith(".yaml") || file.name.endsWith(".yml")) {
+        changeSchemaFormat("yaml");
+      }
+      setSchemaText(content);
+    };
+    reader.readAsText(file);
+  };
+
+  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) loadFile(file);
+    event.target.value = "";
+  };
+
+  useEffect(() => {
+    const onDragOver = (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    };
+    const onDrop = (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const file = e.dataTransfer?.files?.[0];
+      if (!file) return;
+      const ext = file.name.split(".").pop()?.toLowerCase();
+      if (!["json", "yaml", "yml"].includes(ext ?? "")) return;
+      loadFile(file);
+    };
+    document.addEventListener("dragover", onDragOver);
+    document.addEventListener("drop", onDrop);
+    return () => {
+      document.removeEventListener("dragover", onDragOver);
+      document.removeEventListener("drop", onDrop);
+    };
+  }, []);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLInputElement>) => {
@@ -35,7 +85,6 @@ const NavigationBar = () => {
         if (mobileSearchOpen) setMobileSearchOpen(false);
         return;
       }
-
       if (event.key === "Enter") {
         event.preventDefault();
         triggerNavigateMatch(event.shiftKey ? "prev" : "next");
@@ -70,7 +119,6 @@ const NavigationBar = () => {
             className="w-15 h-15 md:w-15 md:h-15"
             draggable="false"
           />
-
           <div className="flex font-mono flex-col">
             <span className="text-2xl font-bold text-[var(--tool-name-color)]">
               Studio
@@ -133,6 +181,42 @@ const NavigationBar = () => {
           >
             <RiSearchLine className="text-[var(--navigation-text-color)]" />
           </button>
+        </li>
+
+        <li className="flex items-center">
+          <input
+            type="file"
+            id="schema-file-input"
+            ref={fileInputRef}
+            onChange={handleFileUpload}
+            accept=".json,.yaml,.yml"
+            className="hidden"
+          />
+          <button
+            className="text-xl cursor-pointer"
+            onClick={() => fileInputRef.current?.click()}
+            data-tooltip-id="upload-file"
+            aria-label="Upload JSON/YAML schema file"
+          >
+            <BsUpload className="text-[var(--navigation-text-color)]" />
+          </button>
+          <Tooltip
+            id="upload-file"
+            content="Upload JSON/YAML (or drag & drop)"
+            style={{ fontSize: "10px" }}
+          />
+        </li>
+
+        <li className="flex items-center">
+          <select
+            onChange={(e) => changeSchemaFormat(e.target.value as SchemaFormat)}
+            className="text-sm border rounded-sm bg-[var(--bg-color)] text-[var(--dropdown-text-color)] border-[var(--navigation-text-color)] cursor-pointer"
+            value={schemaFormat}
+            aria-label="Schema format"
+          >
+            <option value="json">JSON</option>
+            <option value="yaml">YAML</option>
+          </select>
         </li>
 
         <li className="flex items-center">
@@ -202,7 +286,6 @@ const NavigationBar = () => {
           }`}
         >
           <RiSearchLine className="text-[var(--navigation-text-color)] opacity-70" />
-
           <input
             ref={mobileSearchInputRef}
             type="text"

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -11,16 +11,14 @@ import {
 import { Tooltip } from "react-tooltip";
 import { AppContext } from "../contexts/AppContext";
 import FullscreenToggleButton from "./FullscreenToggleButton";
-import type { SchemaFormat } from "../contexts/AppContext";
 
 const NavigationBar = () => {
   const {
     theme,
     toggleTheme,
     isFullScreen,
-    schemaFormat,
-    changeSchemaFormat,
     setSchemaText,
+    changeSchemaFormat,
     searchString,
     setSearchString,
     setSelectedNode,
@@ -205,18 +203,6 @@ const NavigationBar = () => {
             content="Upload JSON/YAML (or drag & drop)"
             style={{ fontSize: "10px" }}
           />
-        </li>
-
-        <li className="flex items-center">
-          <select
-            onChange={(e) => changeSchemaFormat(e.target.value as SchemaFormat)}
-            className="text-sm border rounded-sm bg-[var(--bg-color)] text-[var(--dropdown-text-color)] border-[var(--navigation-text-color)] cursor-pointer"
-            value={schemaFormat}
-            aria-label="Schema format"
-          >
-            <option value="json">JSON</option>
-            <option value="yaml">YAML</option>
-          </select>
         </li>
 
         <li className="flex items-center">

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -22,7 +22,6 @@ const NavigationBar = () => {
     setSelectedNode,
     triggerNavigateMatch,
   } = useContext(AppContext);
-
   const searchInputRef = useRef<HTMLInputElement>(null);
   const mobileSearchInputRef = useRef<HTMLInputElement>(null);
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
@@ -36,6 +35,7 @@ const NavigationBar = () => {
         if (mobileSearchOpen) setMobileSearchOpen(false);
         return;
       }
+
       if (event.key === "Enter") {
         event.preventDefault();
         triggerNavigateMatch(event.shiftKey ? "prev" : "next");
@@ -70,6 +70,7 @@ const NavigationBar = () => {
             className="w-15 h-15 md:w-15 md:h-15"
             draggable="false"
           />
+
           <div className="flex font-mono flex-col">
             <span className="text-2xl font-bold text-[var(--tool-name-color)]">
               Studio
@@ -201,6 +202,7 @@ const NavigationBar = () => {
           }`}
         >
           <RiSearchLine className="text-[var(--navigation-text-color)] opacity-70" />
+          
           <input
             ref={mobileSearchInputRef}
             type="text"

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -1,4 +1,4 @@
-import { BsGithub, BsMoonStars, BsBook, BsSun, BsUpload } from "react-icons/bs";
+import { BsGithub, BsMoonStars, BsBook, BsSun } from "react-icons/bs";
 import { RiSearchLine, RiCloseLine } from "react-icons/ri";
 import {
   type KeyboardEvent,
@@ -17,62 +17,15 @@ const NavigationBar = () => {
     theme,
     toggleTheme,
     isFullScreen,
-    setSchemaText,
-    changeSchemaFormat,
     searchString,
     setSearchString,
     setSelectedNode,
     triggerNavigateMatch,
   } = useContext(AppContext);
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const mobileSearchInputRef = useRef<HTMLInputElement>(null);
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
-
-  const loadFile = (file: File) => {
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const content = e.target?.result as string;
-      if (!content) return;
-      if (file.name.endsWith(".json")) {
-        changeSchemaFormat("json");
-      } else if (file.name.endsWith(".yaml") || file.name.endsWith(".yml")) {
-        changeSchemaFormat("yaml");
-      }
-      setSchemaText(content);
-    };
-    reader.readAsText(file);
-  };
-
-  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file) loadFile(file);
-    event.target.value = "";
-  };
-
-  useEffect(() => {
-    const onDragOver = (e: DragEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
-    };
-    const onDrop = (e: DragEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      const file = e.dataTransfer?.files?.[0];
-      if (!file) return;
-      const ext = file.name.split(".").pop()?.toLowerCase();
-      if (!["json", "yaml", "yml"].includes(ext ?? "")) return;
-      loadFile(file);
-    };
-    document.addEventListener("dragover", onDragOver);
-    document.addEventListener("drop", onDrop);
-    return () => {
-      document.removeEventListener("dragover", onDragOver);
-      document.removeEventListener("drop", onDrop);
-    };
-  }, []);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLInputElement>) => {
@@ -179,30 +132,6 @@ const NavigationBar = () => {
           >
             <RiSearchLine className="text-[var(--navigation-text-color)]" />
           </button>
-        </li>
-
-        <li className="flex items-center">
-          <input
-            type="file"
-            id="schema-file-input"
-            ref={fileInputRef}
-            onChange={handleFileUpload}
-            accept=".json,.yaml,.yml"
-            className="hidden"
-          />
-          <button
-            className="text-xl cursor-pointer"
-            onClick={() => fileInputRef.current?.click()}
-            data-tooltip-id="upload-file"
-            aria-label="Upload JSON/YAML schema file"
-          >
-            <BsUpload className="text-[var(--navigation-text-color)]" />
-          </button>
-          <Tooltip
-            id="upload-file"
-            content="Upload JSON/YAML (or drag & drop)"
-            style={{ fontSize: "10px" }}
-          />
         </li>
 
         <li className="flex items-center">

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -202,7 +202,7 @@ const NavigationBar = () => {
           }`}
         >
           <RiSearchLine className="text-[var(--navigation-text-color)] opacity-70" />
-          
+
           <input
             ref={mobileSearchInputRef}
             type="text"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+export const SESSION_SCHEMA_KEY = "ioflux.schema.editor.content";
+export const SESSION_FORMAT_KEY = "ioflux.schema.editor.format";

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -20,6 +20,9 @@ type AppContextType = {
   schemaFormat: SchemaFormat;
   changeSchemaFormat: (format: SchemaFormat) => void;
 
+  schemaText: string;
+  setSchemaText: (text: string) => void;
+
   selectedNode: SelectedNode | null;
   setSelectedNode: (selectedNode: SelectedNode | null) => void;
 

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -15,7 +15,7 @@ import {
 import defaultSchema from "../data/defaultJSONSchema.json";
 import YAML from "js-yaml";
 
-const SESSION_SCHEMA_KEY = "ioflux.schema.editor.content";
+import { SESSION_SCHEMA_KEY, SESSION_FORMAT_KEY } from "../constants";
 
 const loadSchemaJSON = (key: string): any => {
   const raw = sessionStorage.getItem(key);
@@ -40,9 +40,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   });
 
   const [schemaFormat, setSchemaFormat] = useState<SchemaFormat>(
-    (window.sessionStorage.getItem(
-      "ioflux.schema.editor.format"
-    ) as SchemaFormat) ?? "json"
+    (window.sessionStorage.getItem(SESSION_FORMAT_KEY) as SchemaFormat) ?? "json"
   );
 
   const initialSchemaJSON = loadSchemaJSON(SESSION_SCHEMA_KEY);
@@ -52,8 +50,6 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       ? YAML.dump(initialSchemaJSON)
       : JSON.stringify(initialSchemaJSON, null, 2)
   );
-
-
 
   const toggleTheme = () => {
     setTheme((prev) => {
@@ -65,7 +61,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
 
   const changeSchemaFormat = useCallback(
     (format: SchemaFormat) => {
-      sessionStorage.setItem("ioflux.schema.editor.format", format);
+      sessionStorage.setItem(SESSION_FORMAT_KEY, format);
       setSchemaFormat(format);
       if (format === schemaFormat) return;
       try {

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -12,6 +12,21 @@ import {
   type SelectedNode,
 } from "./AppContext";
 
+import defaultSchema from "../data/defaultJSONSchema.json";
+import YAML from "js-yaml";
+
+const SESSION_SCHEMA_KEY = "ioflux.schema.editor.content";
+
+const loadSchemaJSON = (key: string): any => {
+  const raw = sessionStorage.getItem(key);
+  if (!raw) return defaultSchema;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return defaultSchema;
+  }
+};
+
 export const AppProvider = ({ children }: { children: ReactNode }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isFullScreen, setIsFullScreen] = useState(false);
@@ -29,6 +44,23 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       "ioflux.schema.editor.format"
     ) as SchemaFormat) ?? "json"
   );
+
+  const initialSchemaJSON = loadSchemaJSON(SESSION_SCHEMA_KEY);
+
+  const [schemaText, setSchemaText] = useState<string>(
+    schemaFormat === "yaml"
+      ? YAML.dump(initialSchemaJSON)
+      : JSON.stringify(initialSchemaJSON, null, 2)
+  );
+
+  useEffect(() => {
+    const schemaJSON = loadSchemaJSON(SESSION_SCHEMA_KEY);
+    setSchemaText(
+      schemaFormat === "yaml"
+        ? YAML.dump(schemaJSON)
+        : JSON.stringify(schemaJSON, null, 2)
+    );
+  }, [schemaFormat]);
 
   const toggleTheme = () => {
     setTheme((prev) => {
@@ -59,9 +91,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
 
   const toggleFullScreen = useCallback(() => {
     const el = containerRef.current;
-
     if (!el) return;
-
     if (!document.fullscreenElement) {
       el.requestFullscreen()
         .then(() => setIsFullScreen(true))
@@ -78,7 +108,6 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     const handleFullscreenChange = () => {
       setIsFullScreen(!!document.fullscreenElement);
     };
-
     document.addEventListener("fullscreenchange", handleFullscreenChange);
     return () => {
       document.removeEventListener("fullscreenchange", handleFullscreenChange);
@@ -97,6 +126,8 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     toggleFullScreen,
     schemaFormat,
     changeSchemaFormat,
+    schemaText,
+    setSchemaText,
     selectedNode,
     setSelectedNode,
     searchString,

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -53,14 +53,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       : JSON.stringify(initialSchemaJSON, null, 2)
   );
 
-  useEffect(() => {
-    const schemaJSON = loadSchemaJSON(SESSION_SCHEMA_KEY);
-    setSchemaText(
-      schemaFormat === "yaml"
-        ? YAML.dump(schemaJSON)
-        : JSON.stringify(schemaJSON, null, 2)
-    );
-  }, [schemaFormat]);
+
 
   const toggleTheme = () => {
     setTheme((prev) => {
@@ -70,9 +63,25 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     });
   };
 
-  const changeSchemaFormat = (format: SchemaFormat) => {
-    setSchemaFormat(format);
-  };
+  const changeSchemaFormat = useCallback(
+    (format: SchemaFormat) => {
+      sessionStorage.setItem("ioflux.schema.editor.format", format);
+      setSchemaFormat(format);
+      if (format === schemaFormat) return;
+      try {
+        if (format === "yaml") {
+          const parsed = JSON.parse(schemaText);
+          setSchemaText(YAML.dump(parsed));
+        } else {
+          const parsed = YAML.load(schemaText) as object;
+          setSchemaText(JSON.stringify(parsed, null, 2));
+        }
+      } catch {
+        // If conversion fails, keep existing text as-is
+      }
+    },
+    [schemaFormat, schemaText]
+  );
 
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
   const [searchString, setSearchString] = useState("");

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -110,7 +110,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     const handleFullscreenChange = () => {
       setIsFullScreen(!!document.fullscreenElement);
     };
-    
+
     document.addEventListener("fullscreenchange", handleFullscreenChange);
     return () => {
       document.removeEventListener("fullscreenchange", handleFullscreenChange);

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -91,7 +91,9 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
 
   const toggleFullScreen = useCallback(() => {
     const el = containerRef.current;
+
     if (!el) return;
+
     if (!document.fullscreenElement) {
       el.requestFullscreen()
         .then(() => setIsFullScreen(true))
@@ -108,6 +110,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     const handleFullscreenChange = () => {
       setIsFullScreen(!!document.fullscreenElement);
     };
+    
     document.addEventListener("fullscreenchange", handleFullscreenChange);
     return () => {
       document.removeEventListener("fullscreenchange", handleFullscreenChange);


### PR DESCRIPTION
### Summary
This PR introduces the ability for users to upload their own JSON or YAML schema files directly into the studio. It provides two convenient methods for uploading: a manual file picker in the Navigation Bar and a global, cross-browser compatible drag-and-drop target.

### Key Changes
* **File Upload Button:** Added a new upload action (`BsUpload`) in `NavigationBar.tsx` that triggers a hidden file input, accepting `.json`, `.yaml`, and `.yml` files.
* **Global Drag-and-Drop:** Implemented a silent, global drag-and-drop target so users can drag a schema file anywhere onto the browser window to instantly load it.
* **Auto-format Detection:** Uploading a file automatically detects the extension and switches the editor format (JSON vs YAML) accordingly.

##Closes #340 

### Technical Implementation Details
* **State Lifting (Refactoring):** To allow the `NavigationBar` to update the editor content, the `schemaText` state and its initialization/formatting logic were lifted out of `MonacoEditor.tsx` and moved into the global `AppProvider`. 
* **Firefox Drop Bug Fix:** The drag-and-drop event listeners are intentionally attached directly to the native DOM `document` via `useEffect` (instead of using React synthetic `onDrop` handlers). This ensures `e.preventDefault()` fires correctly at the top level, preventing aggressive browsers like Firefox from intercepting the dropped file and opening it in a new tab.


https://github.com/user-attachments/assets/4f390623-21b6-4f26-a0f0-5ba96303c7e2

