### PR TITLE
Support share schema via URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@monaco-editor/react": "^4.7.0",
         "@tailwindcss/vite": "^4.1.10",
         "@xyflow/react": "^12.8.3",
+        "fflate": "^0.8.2",
         "js-yaml": "^4.1.1",
         "monaco-editor": "^0.52.2",
         "react": "^19.1.0",
@@ -2962,6 +2963,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-studio",
-  "version": "0.2.4-beta",
+  "version": "0.3.0-beta",
   "type": "module",
   "homepage": "studio.ioflux.org",
   "repository": "https://github.com/ioflux-org/studio-json-schema",
@@ -18,6 +18,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@tailwindcss/vite": "^4.1.10",
     "@xyflow/react": "^12.8.3",
+    "fflate": "^0.8.2",
     "js-yaml": "^4.1.1",
     "monaco-editor": "^0.52.2",
     "react": "^19.1.0",

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -12,7 +12,7 @@ const NavigationBar = () => {
     <nav className="h-[8vh] flex justify-between items-center shadow-lg relative z-10">
       <div className="flex items-center text-center select-none">
         <img
-          src={theme === "dark" ? "logo-dark.svg" : "logo-light.svg"}
+          src={theme === "dark" ? "/logo-dark.svg" : "/logo-light.svg"}
           alt="Studio JSON Schema"
           className="w-15 h-15 md:w-15 md:h-15"
           draggable="false"

--- a/src/components/SchemaVisualization.tsx
+++ b/src/components/SchemaVisualization.tsx
@@ -72,7 +72,7 @@ const SchemaVisualization = ({
       </div>
       <div className="absolute bottom-[10px] right-[10px] z-10">
         <img
-          src="trust-badge.svg"
+          src="/trust-badge.svg"
           alt="Local-only processing"
           className="w-9 h-9"
           draggable="false"

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -12,6 +12,9 @@ type AppContextType = {
 
   schemaFormat: SchemaFormat;
   changeSchemaFormat: (format: SchemaFormat) => void;
+
+  schemaContent: string;
+  setSchemaContent: (content: string) => void;
 };
 
 export const AppContext = createContext<AppContextType>({} as AppContextType);

--- a/src/utils/urlSchemaCodec.ts
+++ b/src/utils/urlSchemaCodec.ts
@@ -1,0 +1,108 @@
+import { compressSync, decompressSync } from 'fflate';
+
+function uint8ArrayToBase64URL(arr: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < arr.length; i++) {
+    binary += String.fromCharCode(arr[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function base64URLToUint8Array(str: string): Uint8Array {
+  const padding = (4 - (str.length % 4)) % 4;
+  const padded = str + '='.repeat(padding);
+  
+  const standard = padded.replace(/-/g, '+').replace(/_/g, '/');
+  
+  const binary = atob(standard);
+  const arr = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    arr[i] = binary.charCodeAt(i);
+  }
+  return arr;
+}
+
+export function encodeSchemaToURL(schemaText: string): string | null {
+  try {
+    if (!schemaText || schemaText.trim().length === 0) {
+      return null;
+    }
+    
+    const encoder = new TextEncoder();
+    const bytes = encoder.encode(schemaText);
+
+    const compressed = compressSync(bytes);
+    
+    const encoded = uint8ArrayToBase64URL(compressed);
+    
+    return `/schema/${encoded}`;
+  } catch (error) {
+    console.error('Failed to encode schema to URL:', error);
+    return null;
+  }
+}
+
+export function decodeSchemaFromURL(pathname: string): string | null {
+  try {
+    if (!pathname || !pathname.startsWith('/schema/')) {
+      return null;
+    }
+    
+    const encoded = pathname.substring('/schema/'.length);
+    
+    if (!encoded) {
+      return null;
+    }
+    
+    const compressed = base64URLToUint8Array(encoded);
+    
+    const decompressed = decompressSync(compressed);
+    
+    const decoder = new TextDecoder();
+    const schemaText = decoder.decode(decompressed);
+    
+    if (!schemaText) {
+      console.warn('Failed to decompress schema from URL');
+      return null;
+    }
+    
+    return schemaText;
+  } catch (error) {
+    console.error('Failed to decode schema from URL:', error);
+    return null;
+  }
+}
+
+export function hasSchemaInURL(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  
+  const pathname = window.location.pathname;
+
+  return pathname.startsWith('/schema/') && pathname.length > '/schema/'.length;
+}
+
+export function getSchemaPathFromURL(): string {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+  
+  return window.location.pathname;
+}
+
+export function updateURLWithSchema(schemaText: string): void {
+  try {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    
+    const encodedPath = encodeSchemaToURL(schemaText);
+    
+    if (encodedPath) {
+      window.history.replaceState(null, '', encodedPath);
+    }
+  } catch (error) {
+    console.error('Failed to update URL with schema:', error);
+  }
+}


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Make the schema and its visualization sharable via URL by encoding the schema into the URL, when someone paste the URL if there is encoded schema in the URL it got decoded, put in the editor and got visualized. if there is no schema in the URL(https://studio.ioflux.org/) the default schema is loaded then it got encoded in the URL to be sharable.

Used library to encode and decode schema is [fflate](https://github.com/101arrowz/fflate) i compared more than one library and this one gives the shortest URL

Exmaple URL:
http://localhost:5175/schema/H4sIAH9FkGkAA3VTPU_DMBDd-RVWYARSKrGwMTCAEEXqiBic-JJeFdvBvkgtqP8df6St3aZLlLx77_zu-fJ3xVhxY-sVSF48sWJF1Nunslxbre4ifK9NWwrDGyrns_ns7mFejvzbIEaRCi0NAvU96qYbNkGakgXY2mBPqJUXPbO35eKDLQODxWKFqmWc9WCchaiibQ-erqs11BSx3mhHIQTrKn4KhykuPS9-JTpLxjUNuoBLVO-gWlq54vyI8s0BfZwFdBeLBW8n-6IiaMFkjVEO0tVmadsRezjtKoQBe_TvwzTQ-M7X5Y2AxpZ7SqZb6apK504ccWP4NvPzSiA9NTO0Bx-zvpIbJN4tidOQddcKFt7W1wiwQymUa60shZxdyh1Es0njywJ3okEQiWJ8-86MoX2Rfae3jjkxc6V1B1yNGblnkPl00e8Z7z7TVSEzQNxbH_BxdyYuY2LtAj6xenEspG2GnK_gVDTFL_anspP_xOKGCWyRmOOyWgs4uMlOUYOs3D6exXk47VIqDe9siCWQDPwMaELaxyuP453Yzq_LZ3-1-wce_WWTUwQAAA

## What kind of change does this PR introduce

<!-- What kind of change is this? -->
New Feature 

## Issue Number

<!-- Add issue number here -->

Closes #67

## Screenshots/Video

<!-- If relevant, add screenshots or videos demonstrating the change -->

https://github.com/user-attachments/assets/d33f6c8b-78aa-49f7-a27f-8927a30c2f97


## Does this PR introduce a breaking change?

No

## If relevant, did you update the documentation?

No