### PR TITLE
fix : Search node placeholder visibility issue in dark theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-studio",
-  "version": "0.4.2-beta",
+  "version": "0.4.3-beta",
   "type": "module",
   "homepage": "studio.ioflux.org",
   "repository": "https://github.com/ioflux-org/studio-json-schema",

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -365,7 +365,7 @@ const GraphView = ({
           type="text"
           maxLength={30}
           placeholder="search node"
-          className="outline-none text-[var(--bottom-bg-color)] border-b-2 text-center w-[150px]"
+          className="outline-none text-[var(--text-color)] border-b-2 border-[var(--text-color)] text-center w-[150px]"
           onChange={handleChange}
         />
 


### PR DESCRIPTION
## Summary
Fix search node placeholder visibility issue in dark theme by improving contrast and input styling.

## What kind of change does this PR introduce
- Bug fix (UI/UX improvement)

## Issue Number
Closes #89

## Screenshots
Before: Placeholder text was faint in dark theme  
<img width="180" height="74" alt="image" src="https://github.com/user-attachments/assets/7c86a2e3-9693-425d-8e4c-669ec82b08fe" />

After: Placeholder text is clearly visible with improved contrast
<img width="180" height="74" alt="Screenshot from 2026-02-18 21-48-30" src="https://github.com/user-attachments/assets/e06de30d-1c1b-40ec-a50e-ff97197a7bee" />


## Does this PR introduce a breaking change?
No

## If relevant, did you update the documentation?
No
