### PR TITLE
fix: correct processAST call in contains handler to resolve graph rendering issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-studio",
-  "version": "0.5.2-beta",
+  "version": "0.5.3-beta",
   "type": "module",
   "homepage": "studio.ioflux.org",
   "repository": "https://github.com/ioflux-org/studio-json-schema",

--- a/src/utils/processAST.ts
+++ b/src/utils/processAST.ts
@@ -353,10 +353,9 @@ const keywordHandlerMap: KeywordHandlerMap = {
     },
     // "https://json-schema.org/keyword/dependentSchemas": createBasicKeywordHandler("dependentSchemas"),
     "https://json-schema.org/keyword/contains": (ast, keywordValue, nodes, edges, parentId, nodeDepth, renderedNodes) => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
-        processAST({ ast, keywordValue: keywordValue["contains"], nodes, edges, parentId, renderedNodes, nodeTitle: "contains", nodeDepth });
-        return { key: "contains", data: { value: keywordValue, ellipsis: "{ ... }" } }
+        const value = keywordValue as { contains: string; minContains: number; maxContains: number };
+        processAST({ ast, schemaUri: value.contains, nodes, edges, parentId, childId: "contains", renderedNodes, nodeTitle: "contains", nodeDepth });
+        return { key: "contains", data: { value: value.contains, ellipsis: "{ ... }" } }
     },
     "https://json-schema.org/keyword/items": (ast, keywordValue, nodes, edges, parentId, nodeDepth, renderedNodes) => {
         const value = keywordValue as string[];


### PR DESCRIPTION
## Summary

Fixes broken graph rendering for the `contains` keyword by correcting the argument passed to `processAST`. The issue was causing AST traversal to fail, resulting in missing or incorrect graph nodes.

---

## What kind of change does this PR introduce

🐛 Bug fix

---

## Issue Number

Closes #107

---

## Screenshots/Video

Before:

* `contains` node was not expanding correctly
* Graph showed incorrect/stale nodes
* Console error: `schemaNodes is undefined`

After:

* `contains` correctly expands in the graph
* Nested schema (e.g., `type: string`) is rendered properly
* No runtime errors observed

<img width="1785" height="962" alt="image" src="https://github.com/user-attachments/assets/85733292-8f97-4336-98ca-8a867761c2ae" />


---

## Does this PR introduce a breaking change?

No

---

## If relevant, did you update the documentation?

No
