### PR TITLE
feat: A refined bottom bar and a minimap for overview 

### DIFF
--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -19,6 +19,8 @@ import {
   Position,
   BackgroundVariant,
   useReactFlow,
+  MiniMap,
+  type MiniMapNodeProps,
   type NodeMouseHandler,
 } from "@xyflow/react";
 
@@ -43,13 +45,50 @@ const NODE_WIDTH = 172;
 const NODE_HEIGHT = 36;
 const HORIZONTAL_GAP = 150;
 
+const MinimapCustomNode = ({ x, y, width, height, color, data, selected }: MiniMapNodeProps & { data?: any }) => {
+  const { theme } = useContext(AppContext);
+  const isDark = theme === "dark";
+
+  const bg = isDark ? "black" : "#ffffff";
+  const borderColor = color || (isDark ? "#444" : "#ccc");
+  const headerBg = color || borderColor;
+  const textColor = isDark ? "#ffffff" : "#000000";
+
+  if (data?.isBooleanNode) {
+    return (
+      <g transform={`translate(${x}, ${y})`}>
+        <rect width={width} height={height} fill={headerBg} fillOpacity={0.5} stroke={selected ? "var(--node-key-color)" : borderColor} strokeWidth={selected ? 6 : 4} rx={16} />
+      </g>
+    );
+  }
+
+  const rowCount = Math.max(0, Math.floor((height - 30) / 26));
+
+  return (
+    <g transform={`translate(${x}, ${y})`}>
+      <rect width={width} height={height} fill={bg} stroke={selected ? "var(--node-key-color)" : borderColor} strokeWidth={selected ? 4 : 2} rx={4} />
+
+      <path d={`M 0 4 Q 0 0 4 0 L ${width - 4} 0 Q ${width} 0 ${width} 4 L ${width} 26 L 0 26 Z`} fill={headerBg} fillOpacity={0.3} />
+      <line x1={0} y1={26} x2={width} y2={26} stroke={borderColor} strokeWidth={1} />
+
+      {height > 30 && Array.from({ length: rowCount }).map((_, i) => (
+        <g key={i} transform={`translate(0, ${30 + i * 26})`}>
+          <rect x={4} y={2} width={width - 8} height={22} fill={borderColor} fillOpacity={0.1} rx={2} />
+          <rect x={8} y={9} width={30 + (i % 3) * 10} height={8} fill={borderColor} rx={2} />
+          <rect x={width / 2} y={9} width={20 + (i % 4) * 15} height={8} fill={textColor} fillOpacity={0.2} rx={2} />
+        </g>
+      ))}
+    </g>
+  );
+};
+
 const GraphView = ({
   compiledSchema,
 }: {
   compiledSchema: CompiledSchema | null;
 }) => {
   const { setCenter, getZoom, fitView } = useReactFlow();
-  const { selectedNode, setSelectedNode } = useContext(AppContext);
+  const { theme, selectedNode, setSelectedNode, showMinimap } = useContext(AppContext);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const [nodes, setNodes, onNodeChange] = useNodesState<GraphNode>([]);
@@ -365,6 +404,21 @@ const GraphView = ({
           color="var(--reactflow-bg-sub-pattern-color)"
         />
         <Controls />
+        {showMinimap && (
+          <MiniMap
+            nodeComponent={MinimapCustomNode as any}
+            pannable
+            zoomable
+            style={{
+              backgroundColor: theme === "dark" ? "#404040" : "var(--bg-color)",
+              borderColor: theme === "dark" ? "gray" : "var(--node-border-color)",
+              borderWidth: "1px",
+              borderStyle: "solid"
+            }}
+            maskColor={theme === "dark" ? "rgba(0, 0, 0, 0.4)" : "var(--minimap-mask-color, rgba(0, 0, 0, 0.1))"}
+            className="rounded-md overflow-hidden"
+          />
+        )}
       </ReactFlow>
 
       {selectedNode && (

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -26,6 +26,7 @@ import EditorToggleButton from "./EditorToggleButton";
 import { parseSchema } from "../utils/parseSchema";
 import YAML from "js-yaml";
 import type { JSONSchema } from "@apidevtools/json-schema-ref-parser";
+import { Tooltip } from "react-tooltip";
 
 type ValidationStatus = {
   status: "success" | "warning" | "error";
@@ -255,13 +256,13 @@ const MonacoEditor = () => {
         setSchemaValidation(
           !dialect && typeof parsedSchema !== "boolean"
             ? {
-                status: "warning",
-                message: VALIDATION_UI["warning"].message,
-              }
+              status: "warning",
+              message: VALIDATION_UI["warning"].message,
+            }
             : {
-                status: "success",
-                message: VALIDATION_UI["success"].message,
-              }
+              status: "success",
+              message: VALIDATION_UI["success"].message,
+            }
         );
 
         saveSchemaJSON(SESSION_SCHEMA_KEY, copy);
@@ -281,9 +282,8 @@ const MonacoEditor = () => {
   return (
     <div
       ref={containerRef}
-      className={`h-[92vh] flex flex-col ${
-        isAnimating ? "panel-animating" : ""
-      }`}
+      className={`h-[92vh] flex flex-col ${isAnimating ? "panel-animating" : ""
+        }`}
     >
       {isFullScreen && (
         <div className="w-full px-1 bg-[var(--view-bg-color)] justify-items-end">
@@ -299,22 +299,38 @@ const MonacoEditor = () => {
           ref={editorPanelRef}
           collapsible
         >
-          <Editor
-            height="90%"
-            width="100%"
-            language={schemaFormat}
-            value={schemaText}
-            theme={theme === "light" ? "vs-light" : "vs-dark"}
-            options={{
-              minimap: { enabled: false },
-              occurrencesHighlight: "off",
-            }}
-            onChange={(value) => setSchemaText(value ?? "")}
-            onMount={handleEditorDidMount}
-          />
-          <div className="flex-1 p-2 bg-[var(--validation-bg-color)] text-sm overflow-y-auto">
-            <div className={VALIDATION_UI[schemaValidation.status].className}>
+          <div className="flex-1 min-h-0 flex">
+            <Editor
+              height="100%"
+              width="100%"
+              language={schemaFormat}
+              value={schemaText}
+              theme={theme === "light" ? "vs-light" : "vs-dark"}
+              options={{
+                minimap: { enabled: false },
+                occurrencesHighlight: "off",
+              }}
+              onChange={(value) => setSchemaText(value ?? "")}
+              onMount={handleEditorDidMount}
+            />
+          </div>
+          <div className="flex items-center justify-between px-2 py-1 bg-[var(--validation-bg-color)] text-xs border-t border-[var(--popup-border-color)] shrink-0">
+            <div className={`truncate ${VALIDATION_UI[schemaValidation.status].className}`}>
               {schemaValidation.message}
+            </div>
+            <div className="flex items-center flex-shrink-0 ml-2">
+              <img
+                src="trust-badge.svg"
+                alt="Local-only processing"
+                className="w-5 h-5 opacity-80 hover:opacity-100 transition-opacity"
+                draggable="false"
+                data-tooltip-id="local-only-tooltip"
+              />
+              <Tooltip
+                id="local-only-tooltip"
+                content="Your data never leaves your device. All processing happens locally."
+                style={{ fontSize: "10px", zIndex: 100 }}
+              />
             </div>
           </div>
         </Panel>

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -1,11 +1,12 @@
 import { BsGithub, BsMoonStars, BsBook, BsSun } from "react-icons/bs";
+import { MdMap } from "react-icons/md";
 import { useContext } from "react";
 import { Tooltip } from "react-tooltip";
 import { AppContext, type SchemaFormat } from "../contexts/AppContext";
 import FullscreenToggleButton from "./FullscreenToggleButton";
 
 const NavigationBar = () => {
-  const { theme, toggleTheme, schemaFormat, changeSchemaFormat } =
+  const { theme, toggleTheme, schemaFormat, changeSchemaFormat, showMinimap, setShowMinimap } =
     useContext(AppContext);
 
   return (
@@ -54,7 +55,21 @@ const NavigationBar = () => {
           <Tooltip
             id="toggle-theme"
             content="Better visuals in dark mode"
-            style={{ fontSize: "10px" }}
+            style={{ fontSize: "10px", zIndex: 100 }}
+          />
+        </li>
+        <li>
+          <button
+            className={`text-xl cursor-pointer transition-opacity ${!showMinimap && "opacity-50"}`}
+            onClick={() => setShowMinimap(!showMinimap)}
+            data-tooltip-id="toggle-minimap"
+          >
+            <MdMap className="text-[var(--navigation-text-color)]" />
+          </button>
+          <Tooltip
+            id="toggle-minimap"
+            content={showMinimap ? "Hide Minimap" : "Show Minimap"}
+            style={{ fontSize: "10px", zIndex: 100 }}
           />
         </li>
         <li>

--- a/src/components/SchemaVisualization.tsx
+++ b/src/components/SchemaVisualization.tsx
@@ -1,7 +1,6 @@
 import GraphView from "./GraphView";
 import { type CompiledSchema } from "@hyperjump/json-schema/experimental";
 import { ReactFlowProvider } from "@xyflow/react";
-import { Tooltip } from "react-tooltip";
 
 const SchemaVisualization = ({
   compiledSchema,
@@ -13,20 +12,6 @@ const SchemaVisualization = ({
       <ReactFlowProvider>
         <GraphView compiledSchema={compiledSchema} />
       </ReactFlowProvider>
-      <div className="absolute bottom-[10px] right-[10px] z-10">
-        <img
-          src="trust-badge.svg"
-          alt="Local-only processing"
-          className="w-9 h-9"
-          draggable="false"
-          data-tooltip-id="local-only-tooltip"
-        />
-      </div>
-      <Tooltip
-        id="local-only-tooltip"
-        content="Your data never leaves your device. All processing happens locally."
-        style={{ fontSize: "10px" }}
-      />
     </>
   );
 };

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -21,6 +21,9 @@ type AppContextType = {
   selectedNode: SelectedNode | null;
 
   setSelectedNode: (selectedNode: SelectedNode | null) => void;
+
+  showMinimap: boolean;
+  setShowMinimap: (show: boolean) => void;
 };
 
 export const AppContext = createContext<AppContextType>({} as AppContextType);

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -39,6 +39,8 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
 
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
 
+  const [showMinimap, setShowMinimap] = useState(true);
+
   const toggleFullScreen = useCallback(() => {
     const el = containerRef.current;
 
@@ -81,6 +83,8 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     changeSchemaFormat,
     selectedNode,
     setSelectedNode,
+    showMinimap,
+    setShowMinimap,
   };
 
   return <AppContext.Provider value={value}>{children}</AppContext.Provider>;


### PR DESCRIPTION
## Summary

Refines the current editor bar and introduces a minimap.

## What kind of change does this PR introduce

The height and padding of the bottom bar is adjusted and the safety icon is shifted to the bottom bar and the minimap replaces the icon in the bottom right corner. 
Also the minimap is toggleable and the selected node is highlighted on the minimap.
More improvements can improve the minimap more as the current package has limited access.

## Issue Number

Closes #112

## Screenshots/Video

<img width="735" height="148" alt="Screenshot 2026-02-23 212722" src="https://github.com/user-attachments/assets/a0c0a190-05f0-48a2-a955-255f08b4c54c" />

<img width="1919" height="868" alt="Screenshot 2026-02-23 212737" src="https://github.com/user-attachments/assets/0dcb73fd-c4cb-457d-8aeb-d5ef9d1c32c0" />

<img width="1919" height="867" alt="Screenshot 2026-02-23 212748" src="https://github.com/user-attachments/assets/c32a0cd5-0423-4a4e-aa00-5e675b429cb8" />


## Does this PR introduce a breaking change?

No.

## If relevant, did you update the documentation?

No.
