### PR TITLE
fix: Reset editor panel to default width on reopen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-studio",
-  "version": "0.5.6-beta",
+  "version": "0.5.5-beta",
   "type": "module",
   "homepage": "studio.ioflux.org",
   "repository": "https://github.com/ioflux-org/studio-json-schema",

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -43,6 +43,7 @@ const DEFAULT_SCHEMA_ID = "https://studio.ioflux.org/schema";
 const DEFAULT_SCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema";
 const SESSION_SCHEMA_KEY = "ioflux.schema.editor.content";
 const SESSION_FORMAT_KEY = "ioflux.schema.editor.format";
+const DEFAULT_EDITOR_PANEL_WIDTH = 25; // in percentage
 
 const JSON_SCHEMA_DIALECTS = [
   "https://json-schema.org/draft/2020-12/schema",
@@ -129,7 +130,7 @@ const MonacoEditor = () => {
     if (editorVisible) {
       editorPanelRef.current.collapse();
     } else {
-      editorPanelRef.current.resize(25);
+      editorPanelRef.current.resize(DEFAULT_EDITOR_PANEL_WIDTH);
     }
 
     setEditorVisible((prev) => !prev);
@@ -295,7 +296,7 @@ const MonacoEditor = () => {
       <PanelGroup direction="horizontal">
         <Panel
           className="flex flex-col"
-          defaultSize={25}
+          defaultSize={DEFAULT_EDITOR_PANEL_WIDTH}
           ref={editorPanelRef}
           collapsible
         >


### PR DESCRIPTION
## Summary

Fixes a UX bug where the editor panel would reopen using its previously resized width, which could be unexpectedly wide or narrow.

Now, whenever the panel is expanded, it resets to the default `25%` width to ensure layout consistency and predictability.

## What kind of change does this PR introduce?

- [x] 🐛 Bug fix (UX)


## Issue Number

closes #121 

## Screenshots/Video


https://github.com/user-attachments/assets/935c93c5-1145-4075-a8d5-6516c25dc540



## Breaking change?

No