### PR TITLE
feat: improve error message for unsupported JSON Schema dialects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "json-schema-studio",
-  "version": "0.5.3-beta",
+  "version": "0.5.6-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "json-schema-studio",
-      "version": "0.5.3-beta",
+      "version": "0.5.6-beta",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^14.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-studio",
-  "version": "0.5.6-beta",
+  "version": "0.5.7-beta",
   "type": "module",
   "homepage": "studio.ioflux.org",
   "repository": "https://github.com/ioflux-org/studio-json-schema",

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -45,6 +45,13 @@ const SESSION_SCHEMA_KEY = "ioflux.schema.editor.content";
 const SESSION_FORMAT_KEY = "ioflux.schema.editor.format";
 const DEFAULT_EDITOR_PANEL_WIDTH = 25; // in percentage
 
+const DIALECT_URL_TO_DIALECT: Record<string, string> = {
+  "https://json-schema.org/draft/2020-12/schema": "2020-12",
+  "https://json-schema.org/draft/2019-09/schema": "2019-09",
+  "http://json-schema.org/draft-07/schema#": "draft-07",
+  "http://json-schema.org/draft-06/schema#": "draft-06",
+  "http://json-schema.org/draft-04/schema#": "draft-04",
+};
 const JSON_SCHEMA_DIALECTS = [
   "https://json-schema.org/draft/2020-12/schema",
   "https://json-schema.org/draft/2019-09/schema",
@@ -231,7 +238,7 @@ const MonacoEditor = () => {
           JSON_SCHEMA_DIALECTS.includes(dialectVersion) &&
           !SUPPORTED_DIALECTS.includes(dialectVersion)
         ) {
-          throw new Error(`Dialect "${dialectVersion}" is not supported yet.`);
+          throw new Error(`Unsupported JSON Schema version. Currently, this tool only supports dialect '${DIALECT_URL_TO_DIALECT[DEFAULT_SCHEMA_DIALECT]}'. Your schema uses '${DIALECT_URL_TO_DIALECT[dialectVersion]}'.`);
         }
 
         const schemaDocument = buildSchemaDocument(


### PR DESCRIPTION
## Summary

This PR improves the error message shown when a user inputs a JSON schema with an unsupported dialect (e.g., draft-07 or 2019-09). The message now clearly states the currently supported dialect and which dialect the user's schema uses.

## What kind of change does this PR introduce

- Enhancement (UX improvement)
- Improves user experience for beginners by providing a clear error message for unsupported JSON dialects.

## Issue Number

Closes #127 

## Screenshots/Video

![Screenshot 2026-02-27 031158](https://github.com/user-attachments/assets/a2ee6e8f-8ea9-444a-9a99-fc846793c338)

## Does this PR introduce a breaking change?

No breaking changes.

## If relevant, did you update the documentation?

No documentation updates required.

