### PR TITLE
fix: Node color defaults to gray when only explicit "type" keyword is present (no type-specific keywords)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-studio",
-  "version": "0.5.6-beta",
+  "version": "0.5.7-beta",
   "type": "module",
   "homepage": "studio.ioflux.org",
   "repository": "https://github.com/ioflux-org/studio-json-schema",

--- a/src/utils/inferSchemaType.ts
+++ b/src/utils/inferSchemaType.ts
@@ -1,8 +1,8 @@
 import type { GraphNode } from "./processAST";
 
 export const inferSchemaType = (nodeData: GraphNode["data"]["nodeData"]): [string, string] => {
-    if (typeof nodeData.type === "string") {
-        return ["objectSchema", nodeData.type];
+    if (nodeData.type && typeof nodeData.type.value === "string") {
+        return ["objectSchema", nodeData.type.value];
     }
 
     const objectKeywords = new Set([


### PR DESCRIPTION
## Summary

Fix incorrect node coloring in inferSchemaType.ts. When a schema node only has an explicit type keyword (e.g. "type": "string") with no other type-specific keywords, the node color defaults to gray instead of the correct type color (magenta for string, mint for integer, yellow for boolean). Root cause: typeof nodeData.type === "string" checks the NodeDataValue object instead of its .value property, so the condition is always false.

## What kind of change does this PR introduce

Bug fix

## Issue Number

Closes #136

## Screenshots/Video

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/6cda6ed6-d857-4ab8-9e8d-1ae636380299) | ![After](https://github.com/user-attachments/assets/43ba9cfc-16c0-46c1-9ee1-48a15aae3a42) |

## Does this PR introduce a breaking change?

No

## If relevant, did you update the documentation?

No, this is an internal logic fix with no documentation impact.