### PR TITLE
Fix for hiding searchbar when pop up appears!

### DIFF
--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -392,7 +392,9 @@ const GraphView = ({
           </button>
         </div>
       )}
-      <div className="absolute bottom-[10px] left-[50px] flex items-center gap-2">
+      {/* Hide search bar when node details popup is open */}
+      {!selectedNode && (
+        <div className="absolute bottom-[10px] left-[50px] flex items-center gap-2">
         <div className="relative">
           <input
             type="text"
@@ -443,7 +445,8 @@ const GraphView = ({
             </button>
           </div>
         )}
-      </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

This PR implements a UX improvement where the search bar at the bottom left disappears when a node details popup is opened, and reappears when the popup is closed.

Changes Made
File: 
GraphView.tsx

Modified the search bar rendering logic to conditionally display based on the selectedNode state:

{/* Hide search bar when node details popup is open */}
{!selectedNode && (
  <div className="absolute bottom-[10px] left-[50px] flex items-center gap-2">
    {/* Search bar content */}
  </div>
)}

Technical Details
Added conditional rendering using {!selectedNode && ...} wrapper around the search bar section
The search bar is now hidden when selectedNode has a value (popup is open)
The search bar reappears when selectedNode is null (popup is closed)
No changes to existing functionality or state management
Behavior
Before:

Search bar remained visible when node details popup was open
Could cause visual clutter and confusion
After:

Search bar automatically hides when any node is clicked and popup appears
Search bar reappears when popup is closed (either by clicking close button or clicking outside)
Cleaner UI with better focus on the active popup
Testing
Test the following scenarios:

Click on any node → Search bar should disappear
Close the popup → Search bar should reappear
Search for a node, then click on it → Search bar should disappear
Close popup and verify search state is preserved