### PR TITLE
fix: remove commented-out base path referencing old project name

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,6 @@ import tailwindcss from '@tailwindcss/vite';
 
 // https://vite.dev/config/
 export default defineConfig({
-  // base : '/visualize-json-schema/',
-  plugins: [react(), tailwindcss()],
+plugins: [react(), tailwindcss()],
   
 })


### PR DESCRIPTION
## Summary

Removes a commented-out `base` path in `vite.config.ts` that referenced the old project name `/visualize-json-schema/`. This line was leftover from a previous rename and serves no purpose.

## What kind of change does this PR introduce

Code cleanup removes dead commented-out code.

## Issue Number

Closes #163

## Screenshots/Video

Not applicable because no UI changes.

## Does this PR introduce a breaking change?

No.

## If relevant, did you update the documentation?

No.
