### PR TITLE
feat: add dependentSchemas keyword handler

### DIFF
--- a/src/utils/processAST.ts
+++ b/src/utils/processAST.ts
@@ -350,8 +350,25 @@ const keywordHandlerMap: KeywordHandlerMap = {
         }
         return { key: "patternProperties", data: { value: getArrayFromNumber(value.length) } }
     },
-    // "https://json-schema.org/keyword/dependentSchemas": createBasicKeywordHandler("dependentSchemas"),
-    "https://json-schema.org/keyword/contains": (ast, keywordValue, nodes, edges, parentId, nodeDepth, renderedNodes) => {
+    "https://json-schema.org/keyword/dependentSchemas": (ast, keywordValue, nodes, edges, parentId, nodeDepth, renderedNodes) => {
+        const value = keywordValue as [string, string][];
+        const propertyNames = [];
+        for (const [key, schemaUri] of value) {
+            propertyNames.push(key);
+            processAST({
+                ast,
+                schemaUri,
+                nodes,
+                edges,
+                parentId,
+                renderedNodes,
+                childId: key,
+                nodeTitle: `dependentSchemas["${key}"]`,
+                nodeDepth
+            });
+        }
+        return { key: "dependentSchemas", data: { value: propertyNames } }
+    }, "https://json-schema.org/keyword/contains": (ast, keywordValue, nodes, edges, parentId, nodeDepth, renderedNodes) => {
         const value = keywordValue as { contains: string; minContains: number; maxContains: number };
         processAST({ ast, schemaUri: value.contains, nodes, edges, parentId, childId: "contains", renderedNodes, nodeTitle: "contains", nodeDepth });
         return { key: "contains", data: { value: value.contains, ellipsis: "{ ... }" } }


### PR DESCRIPTION
## What this does
Implements the missing `dependentSchemas` keyword handler in `processAST.ts`.

## Problem
The `dependentSchemas` handler was commented out, causing the fallback 
handler to trigger with " This keyword handler is not implemented yet!" 
for any schema using this keyword.

## Solution
After inspecting the AST, I found Hyperjump compiles `dependentSchemas` 
as an array of `[propertyName, schemaUri]` tuples , same shape as 
`patternProperties`. The handler iterates these tuples and calls 
`processAST` for each, creating child nodes labeled 
`dependentSchemas["propertyName"]` connected to the parent.

## Testing
Tested locally with a schema using `dependentSchemas` ,child nodes 
render correctly with edges connecting to the parent.