### PR TITLE
 Fix Node-click highlighting in editor fails when using YAML format #167

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^14.1.1",
     "@dagrejs/dagre": "^1.1.5",
+    "@hyperjump/browser": "^1.3.1",
     "@hyperjump/json-schema": "^1.14.1",
     "@monaco-editor/react": "^4.7.0",
     "@tailwindcss/vite": "^4.1.10",
@@ -26,7 +27,8 @@
     "react-icons": "^5.5.0",
     "react-resizable-panels": "^3.0.3",
     "react-tooltip": "^5.29.1",
-    "tailwindcss": "^4.1.10"
+    "tailwindcss": "^4.1.10",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -25,6 +25,7 @@ import FullscreenToggleButton from "./FullscreenToggleButton";
 import EditorToggleButton from "./EditorToggleButton";
 import { parseSchema } from "../utils/parseSchema";
 import YAML from "js-yaml";
+import { parseDocument, isNode, type Node } from "yaml";
 import type { JSONSchema } from "@apidevtools/json-schema-ref-parser";
 
 type ValidationStatus = {
@@ -167,14 +168,47 @@ const MonacoEditor = () => {
         return /^\d+$/.test(decoded) ? parseInt(decoded, 10) : decoded;
       });
 
-    const tree = parseTree(text);
-    if (!tree) return;
+    let offset = -1;
+    let length = 0;
 
-    const node = findNodeAtLocation(tree, path);
+    if (schemaFormat === "yaml") {
+      const doc = parseDocument(text);
+      if (doc) {
+        let current: any = doc.contents;
+        for (const segment of path) {
+          if (current && typeof current === 'object') {
+            if ('get' in current) {
+              current = current.get(segment, true);
+            } else {
+              current = current[segment];
+            }
+          } else {
+            current = undefined;
+            break;
+          }
+        }
+        if (isNode(current as Node)) {
+          const range = (current as Node).range;
+          if (range) {
+            offset = range[0];
+            length = range[1] - range[0];
+          }
+        }
+      }
+    } else {
+      const tree = parseTree(text);
+      if (tree) {
+        const node = findNodeAtLocation(tree, path);
+        if (node) {
+          offset = node.offset;
+          length = node.length;
+        }
+      }
+    }
 
-    if (node) {
-      const startPos = model.getPositionAt(node.offset);
-      const endPos = model.getPositionAt(node.offset + node.length);
+    if (offset !== -1) {
+      const startPos = model.getPositionAt(offset);
+      const endPos = model.getPositionAt(offset + length);
 
       editorRef.current.revealPositionInCenter(startPos);
       editorRef.current.setPosition(startPos);
@@ -256,13 +290,13 @@ const MonacoEditor = () => {
         setSchemaValidation(
           !dialect && typeof parsedSchema !== "boolean"
             ? {
-                status: "warning",
-                message: VALIDATION_UI["warning"].message,
-              }
+              status: "warning",
+              message: VALIDATION_UI["warning"].message,
+            }
             : {
-                status: "success",
-                message: VALIDATION_UI["success"].message,
-              }
+              status: "success",
+              message: VALIDATION_UI["success"].message,
+            }
         );
 
         saveSchemaJSON(SESSION_SCHEMA_KEY, copy);
@@ -282,9 +316,8 @@ const MonacoEditor = () => {
   return (
     <div
       ref={containerRef}
-      className={`h-[92vh] flex flex-col ${
-        isAnimating ? "panel-animating" : ""
-      }`}
+      className={`h-[92vh] flex flex-col ${isAnimating ? "panel-animating" : ""
+        }`}
     >
       {isFullScreen && (
         <div className="w-full px-1 bg-[var(--view-bg-color)] justify-items-end">


### PR DESCRIPTION
## Summary

This PR fixes a bug where clicking a node in the graph visualization failed to highlight the corresponding code in the Monaco editor when using the `YAML format`.

The Problem
The editor synchronization logic relied exclusively on `jsonc-parser` to find node offsets. `jsonc-parser` does not support YAML, resulting in `undefined` AST trees and early returns when the schema was formatted as YAML.
<!-- Brief description of what this PR does -->

## What kind of change does this PR introduce

<!-- What kind of change is this? -->

Introduced the `yaml` library to handle AST parsing for YAML content.
Refactored the synchronization logic in `MonacoEditor.tsx`
 to detect the current `schemaFormat`
Implemented a YAML AST traversal to correctly resolve property paths to their character offsets and lengths.
Maintained existing JSON support using `jsonc-parser`

## Issue Number

<!-- Add issue number here -->

Closes #167 

## Screenshots/Video

Result:

https://github.com/user-attachments/assets/2f34559e-3c93-43d2-9673-d40254581ca3


<!-- If relevant, add screenshots or videos demonstrating the change -->

## Does this PR introduce a breaking change?
No
<!-- Yes or No, and explain if yes -->

## If relevant, did you update the documentation?

<!-- Yes or No, specify what was updated if yes -->
N/A