### PR TITLE
Remove 'Node not found' log from updateNode

### DIFF
--- a/src/utils/processAST.ts
+++ b/src/utils/processAST.ts
@@ -211,7 +211,6 @@ const generateSourceHandles: GenerateSourceHandles = (key, value, nodeId, defs) 
 
 const updateNode: UpdateNode = (node, update) => {
     if (!node) {
-        console.log(`Node not found`)
         return;
     }
 


### PR DESCRIPTION
## Description
Removes an active `console.log('Node not found')` statement from 
production code in `processAST.ts`.

## Related Issues
resolves #173