### PR TITLE
Fix graph zoom reset when editor panel is resized

### DIFF
--- a/.changeset/silver-teeth-notice.md
+++ b/.changeset/silver-teeth-notice.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": patch
+---
+
+Fix graph zoom reset when editor panel is resized

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -51,7 +51,6 @@ const GraphView = ({
   const { setCenter, getZoom, fitView } = useReactFlow();
   const { selectedNode, setSelectedNode } = useContext(AppContext);
   const containerRef = useRef<HTMLDivElement>(null);
-  const userInteractedRef = useRef(false);
 
   const [nodes, setNodes, onNodeChange] = useNodesState<GraphNode>([]);
   const [edges, setEdges, onEdgeChange] = useEdgesState<GraphEdge>([]);
@@ -226,7 +225,6 @@ const GraphView = ({
 
       // important: reset collision flag when schema changes
       setCollisionResolved(false);
-      userInteractedRef.current = false;
     } catch (err) {
       console.error("Error generating visualization graph: ", err);
     }
@@ -277,12 +275,8 @@ const GraphView = ({
     const observer = new ResizeObserver(() => {
       clearTimeout(timeoutId);
       timeoutId = setTimeout(() => {
-        if (!userInteractedRef.current) {
-          fitView({ duration: 800, padding: 0.05 });
-        } else {
           const currentZoom = getZoom();
           fitView({ duration: 800, minZoom: currentZoom, maxZoom: currentZoom, padding: 0.05 });
-        }
       }, 100);
     });
 
@@ -292,7 +286,7 @@ const GraphView = ({
       observer.disconnect();
       clearTimeout(timeoutId);
     };
-  }, [fitView]);
+  }, []);
 
   useEffect(() => {
     const trimmed = searchString.trim();
@@ -325,7 +319,6 @@ const GraphView = ({
         const y = firstNode.position.y + NODE_HEIGHT / 2;
 
         setCenter(x, y, { zoom: Math.max(getZoom(), 1), duration: 500 });
-        userInteractedRef.current = true;
         setNodes((nds) => {
           let changed = false;
           const newNodes = nds.map((n) => {
@@ -373,9 +366,6 @@ const GraphView = ({
         onNodeClick={onNodeClick}
         onNodesChange={onNodeChange}
         onEdgesChange={onEdgeChange}
-        onMoveStart={(e) => {
-          if (e) userInteractedRef.current = true;
-        }}
         deleteKeyCode={null}
         nodeTypes={nodeTypes}
         minZoom={0.05}
@@ -400,9 +390,7 @@ const GraphView = ({
           gap={20}
           color="var(--reactflow-bg-sub-pattern-color)"
         />
-        <Controls onFitView={() => {
-          userInteractedRef.current = false;
-        }} />
+        <Controls />
       </ReactFlow>
 
       {selectedNode && (
@@ -444,7 +432,6 @@ const GraphView = ({
               onClick={() => {
                 setSearchString("");
                 setNodes((nds) => nds.map((n) => ({ ...n, selected: false })));
-                userInteractedRef.current = false;
                 fitView({ duration: 800, padding: 0.05 });
               }}
               className="absolute right-0 top-1/2 -translate-y-1/2 text-[var(--text-color)] cursor-pointer hover:opacity-70"


### PR DESCRIPTION
## Summary

Fixes the issue where the graph view zoom resets when the editor panel is collapsed or resized.

I explored several approaches to preserve the zoom state during layout changes. However, many of them interfered with the existing rendering logic and caused unintended side effects in the graph view behavior.

To avoid breaking the current logic, this PR introduces an **Auto Zoom toggle in the Navigation Bar**, allowing users to control whether the graph should automatically adjust its zoom when the layout container changes.

This keeps the current functionality available while also giving users the option to maintain a stable zoom level.

Additionally, I made a small UI improvement by **refining the alignment of the header icons** to ensure better visual consistency in the navigation bar.

The solution was implemented with **minimal changes** to avoid affecting existing functionality.


## What kind of change does this PR introduce?

Bug fix — improves graph zoom behavior when the editor panel layout changes.

## Changes

* Added an **Auto Zoom toggle** in the Navigation Bar
* Allows users to enable/disable automatic zoom adjustment when the layout container resizes
* Preserves the current zoom level when Auto Zoom is disabled
* Implemented the solution with **minimal changes** to avoid breaking existing graph rendering logic

## Issue Number

Closes #128

## Screenshots / Video

### Before : 

https://github.com/user-attachments/assets/41439060-39a2-4e9e-8b5f-3cd7847d8f40

### After Changes : 


https://github.com/user-attachments/assets/c4227b6f-28ae-472a-a3ae-9aa8eb0e7a02






## Does this PR introduce a breaking change?

No

## If relevant, did you update the documentation?

No
