### PR TITLE
feat: implement handler for dependentSchemas keyword

### DIFF
--- a/src/utils/processAST.ts
+++ b/src/utils/processAST.ts
@@ -350,7 +350,31 @@ const keywordHandlerMap: KeywordHandlerMap = {
         }
         return { key: "patternProperties", data: { value: getArrayFromNumber(value.length) } }
     },
-    // "https://json-schema.org/keyword/dependentSchemas": createBasicKeywordHandler("dependentSchemas"),
+
+    // ✅ NEW: dependentSchemas handler
+    // dependentSchemas is an object where each key is a property name
+    // and each value is a schema URI that applies when that property is present.
+    // The structure from Hyperjump is an array of [propertyName, schemaUri] tuples,
+    // same shape as patternProperties — so we iterate tuples and call processAST for each.
+    "https://json-schema.org/keyword/dependentSchemas": (ast, keywordValue, nodes, edges, parentId, nodeDepth, renderedNodes) => {
+        const value = keywordValue as [string, string][];
+        for (const [index, item] of value.entries()) {
+            const [propertyName, schemaUri] = item;
+            processAST({
+                ast,
+                schemaUri,
+                nodes,
+                edges,
+                parentId,
+                renderedNodes,
+                childId: String(index),
+                nodeTitle: `dependentSchemas["${propertyName}"]`,
+                nodeDepth
+            });
+        }
+        return { key: "dependentSchemas", data: { value: getArrayFromNumber(value.length) } }
+    },
+
     "https://json-schema.org/keyword/contains": (ast, keywordValue, nodes, edges, parentId, nodeDepth, renderedNodes) => {
         const value = keywordValue as { contains: string; minContains: number; maxContains: number };
         processAST({ ast, schemaUri: value.contains, nodes, edges, parentId, childId: "contains", renderedNodes, nodeTitle: "contains", nodeDepth });


### PR DESCRIPTION
## Summary
Implements the `dependentSchemas` keyword handler in `processAST.ts`.

## What kind of change does this PR introduce
- New keyword handler for `dependentSchemas`

## Issue Number
 - #983

## Screenshots/Video
<img width="2559" height="1394" alt="image" src="https://github.com/user-attachments/assets/7d002210-5101-4113-a7dd-742f2e2c1a69" />

## Does this PR introduce a breaking change?
No — this change is purely additive. The `dependentSchemas` keyword 
previously fell through to the fallback handler which displayed a 
This PR replaces that fallback with a proper implementation. No existing 
keyword handlers are modified, and no existing behavior is changed.

## If relevant, did you update the documentation?
No — this is a handler implementation only