### PR TITLE
fix: handle empty editor state to clear graph and validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-studio",
-  "version": "0.5.12-beta",
+  "version": "0.5.13-beta",
   "type": "module",
   "homepage": "studio.ioflux.org",
   "repository": "https://github.com/ioflux-org/studio-json-schema",

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -213,6 +213,13 @@ const GraphView = ({
 
   useEffect(() => {
     try {
+      if (!compiledSchema) {
+        setNodes([]);
+        setEdges([]);
+        setSelectedNode(null);
+        return;
+      }
+
       const result = generateNodesAndEdges(compiledSchema);
       if (!result) return;
 

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -205,6 +205,10 @@ const MonacoEditor = () => {
   useEffect(() => {
     saveFormat(SESSION_FORMAT_KEY, schemaFormat);
 
+    if (!schemaText.trim()) {
+      return;
+    }
+
     const schemaJSON = loadSchemaJSON(SESSION_SCHEMA_KEY);
 
     setSchemaText(
@@ -215,7 +219,14 @@ const MonacoEditor = () => {
   }, [schemaFormat]);
 
   useEffect(() => {
-    if (!schemaText.trim()) return;
+    if (!schemaText.trim()) {
+      setCompiledSchema(null);
+      setSchemaValidation({
+        status: "error",
+        message: VALIDATION_UI["error"].message + "Schema cannot be empty",
+      });
+      return;
+    }
 
     const timeout = setTimeout(async () => {
       try {


### PR DESCRIPTION
## Summary

This PR fixes how the app behaves when the editor is empty.

Before this change, if all text was deleted from Monaco, the graph could still stay on screen and the validation bar could still look valid. Also, switching JSON/YAML while empty could bring back default content.

Now, when the editor is empty:

- the graph is cleared
- validation shows an error (Schema cannot be empty)
- switching format keeps the editor empty instead of resetting content


## What kind of change does this PR introduce

Bug fix

## Issue Number

<!-- Add issue number here -->

Closes #180 

## Video

https://github.com/user-attachments/assets/ab0713aa-6b0d-44c9-877e-33c835536652

## Does this PR introduce a breaking change?

No

## If relevant, did you update the documentation?

No need to update the documentation
