### PR TITLE
fix: show meaningful label for $ref target nodes in graph view

### DIFF
--- a/.changeset/late-sloths-film.md
+++ b/.changeset/late-sloths-film.md
@@ -1,5 +1,5 @@
 ---
-"json-schema-studio": minor
+"json-schema-studio": patch
 ---
 
 Fix incorrect header label on $ref target nodes in the graph view

--- a/src/utils/processAST.ts
+++ b/src/utils/processAST.ts
@@ -289,7 +289,7 @@ const keywordHandlerMap: KeywordHandlerMap = {
     "https://json-schema.org/keyword/$defs": (ast, keywordValue, nodes, edges, parentId, nodeDepth, renderedNodes) => {
         const value = keywordValue as string[];
         for (const [index, item] of value.entries()) {
-                const defName = `$defs["${item.split("#/$defs/").pop()}"]`;
+            const defName = `$defs["${item.split("#/$defs/").pop()}"]`;
             processAST({ ast, schemaUri: item, nodes, edges, parentId, renderedNodes, childId: String(index), nodeTitle: defName, nodeDepth });
         }
         return { key: "$defs", data: { value: getArrayFromNumber(value.length) } }


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
- Fix incorrect header label on `$ref` target nodes in the graph view
- Nodes referenced via `$ref` were showing a generic `defs[0]` label instead of the actual definition name
- Now derives a meaningful label from the `$ref` URI (e.g. `#/$defs/address` → `$defs/address`)

## What kind of change does this PR introduce

<!-- What kind of change is this? -->
Bug fix
## Issue Number

<!-- Add issue number here -->

Closes #191 

## Screenshots/Video
<img width="1412" height="1004" alt="Screenshot 2026-03-20 at 9 44 51 PM" src="https://github.com/user-attachments/assets/64cb765a-efbc-44a9-92dc-bc0797806924" />

<!-- If relevant, add screenshots or videos demonstrating the change -->

## Does this PR introduce a breaking change?

<!-- Yes or No, and explain if yes -->
No
## If relevant, did you update the documentation?

<!-- Yes or No, specify what was updated if yes -->
No