### PR TITLE
fix: type AppContext containerRef as RefObject

### DIFF
--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, type Ref } from "react";
+import { createContext, type RefObject } from "react";
 
 export type SchemaFormat = "json" | "yaml";
 
@@ -8,7 +8,7 @@ export type SelectedNode = {
 };
 
 type AppContextType = {
-  containerRef: Ref<HTMLDivElement>;
+  containerRef: RefObject<HTMLDivElement>;
   isFullScreen: boolean;
   toggleFullScreen: () => void;
 


### PR DESCRIPTION
Fixes #206

`containerRef` is created with `useRef`, so the context type should be `RefObject<HTMLDivElement>` instead of the broader `Ref` union. This keeps the context contract aligned with how the value is actually used.

Greetings, saschabuehrle
