### PR TITLE
feat: add dependentSchemas keyword handler

### DIFF
--- a/src/utils/processAST.ts
+++ b/src/utils/processAST.ts
@@ -350,7 +350,14 @@ const keywordHandlerMap: KeywordHandlerMap = {
         }
         return { key: "patternProperties", data: { value: getArrayFromNumber(value.length) } }
     },
-    // "https://json-schema.org/keyword/dependentSchemas": createBasicKeywordHandler("dependentSchemas"),
+    "https://json-schema.org/keyword/dependentSchemas": (ast, keywordValue, nodes, edges, parentId, nodeDepth, renderedNodes) => {
+        const propertyNames: string[] = [];
+        for (const [key, schemaUri] of keywordValue as [string, string][]) {
+            propertyNames.push(key);
+            processAST({ ast, schemaUri, nodes, edges, parentId, renderedNodes, childId: key, nodeTitle: `dependentSchemas["${key}"]`, nodeDepth });
+        }
+        return { key: "dependentSchemas", data: { value: propertyNames } };
+    },
     "https://json-schema.org/keyword/contains": (ast, keywordValue, nodes, edges, parentId, nodeDepth, renderedNodes) => {
         const value = keywordValue as { contains: string; minContains: number; maxContains: number };
         processAST({ ast, schemaUri: value.contains, nodes, edges, parentId, childId: "contains", renderedNodes, nodeTitle: "contains", nodeDepth });


### PR DESCRIPTION
## Summary

Implements the `dependentSchemas` keyword handler in `processAST.ts`.

The keyword was previously commented out, causing it to fall back to `fallbackHandler` and display a "not implemented" warning node. This PR adds a proper handler that recursively creates child nodes for each dependent subschema.

The handler was designed by tracing Hyperjump's source (`lib/keywords/dependentSchemas.js`) — `dependentSchemas` compiles via `asyncCollectArray`, producing `[string, string][]` tuples of `[propertyName, schemaUri]`. The property name is used as `childId` (not a numeric index like `patternProperties`) so source handles are meaningful, consistent with the `properties` handler convention.

## What kind of change does this PR introduce

New feature — adds a missing keyword handler

## Issue Number

Closes #

## Screenshots/Video

Schema used for testing:

```json
{
  "type": "object",
  "properties": {
    "name": { "type": "string" },
    "credit_card": { "type": "string" }
  },
  "dependentSchemas": {
    "credit_card": {
      "properties": { "billing_address": { "type": "string" } },
      "required": ["billing_address"]
    }
  }
}
```

<img width="921" height="367" alt="image" src="https://github.com/user-attachments/assets/64e43dea-0727-4c85-8de1-fd7c93c1f662" />

## Does this PR introduce a breaking change?

No

## If relevant, did you update the documentation?

No