### PR TITLE
Fix/ Update search results when graph nodes change

### DIFF
--- a/.changeset/every-paws-wish.md
+++ b/.changeset/every-paws-wish.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": patch
+---
+
+Fix search results not refreshing when schema is modified while search is active

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -305,13 +305,8 @@ const GraphView = ({
     const trimmed = searchString.trim();
 
     const timeout = setTimeout(() => {
-<<<<<<< HEAD
-      if (!trimmed || trimmed.length < 3) {
-        setMatchedNodes([]);
-=======
       if (!trimmed) {
         setMatchedNodes((prev) => (prev.length > 0 ? [] : prev));
->>>>>>> 96819e6 (fix: ui flickering resolution)
         setCurrentMatchIndex(0);
         setErrorMessage("");
         

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -356,7 +356,23 @@ const GraphView = ({
     }, 300);
 
     return () => clearTimeout(timeout);
-  }, [searchString]);
+  }, [searchString, nodes]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (matchCount <= 1) return;
+
+      if (e.key === "ArrowRight" || e.key === "Enter") {
+        e.preventDefault();
+        navigateMatch("next");
+      } else if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        navigateMatch("prev");
+      }
+    },
+    [matchCount, navigateMatch]
+  );
+
   return (
     <div
       ref={containerRef}

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -305,12 +305,31 @@ const GraphView = ({
     const trimmed = searchString.trim();
 
     const timeout = setTimeout(() => {
+<<<<<<< HEAD
       if (!trimmed || trimmed.length < 3) {
         setMatchedNodes([]);
+=======
+      if (!trimmed) {
+        setMatchedNodes((prev) => (prev.length > 0 ? [] : prev));
+>>>>>>> 96819e6 (fix: ui flickering resolution)
         setCurrentMatchIndex(0);
         setErrorMessage("");
-        setNodes((nds) => nds.map((n) => ({ ...n, selected: false })));
-        fitView({ duration: 800, padding: 0.05 });
+        
+        setNodes((nds) => {
+          let hasSelected = false;
+          const newNodes = nds.map((n) => {
+            if (n.selected) hasSelected = true;
+            return { ...n, selected: false };
+          });
+          
+          if (hasSelected) {
+            setTimeout(() => {
+              fitView({ duration: 800, padding: 0.05 });
+            }, 0);
+            return newNodes;
+          }
+          return nds;
+        });
         return;
       }
 
@@ -324,26 +343,34 @@ const GraphView = ({
               return searchWords.every((word) => titleKeyWords.includes(word));
             });
 
-      setMatchedNodes(foundNodes);
+      setMatchedNodes((prev) => {
+        if (
+          prev.length === foundNodes.length &&
+          prev.every((n, i) => n.id === foundNodes[i].id)
+        ) {
+          return prev;
+        }
+        return foundNodes;
+      });
 
       if (foundNodes.length > 0) {
-        setCurrentMatchIndex(0);
-        const firstNode = foundNodes[0];
-        const x = firstNode.position.x + NODE_WIDTH / 2;
-        const y = firstNode.position.y + NODE_HEIGHT / 2;
-
-        setSelectedNode({
-          id: firstNode.id,
-        });
-
-        setCenter(x, y, { zoom: Math.max(getZoom(), 1), duration: 500 });
+        const targetNode = foundNodes[currentMatchIndex % foundNodes.length];
+        
         setNodes((nds) => {
           let changed = false;
           const newNodes = nds.map((n) => {
-            const selected = n.id === firstNode.id;
+            const selected = n.id === targetNode.id;
             if (n.selected !== selected) changed = true;
             return { ...n, selected };
           });
+
+          if (changed) {
+            const x = targetNode.position.x + NODE_WIDTH / 2;
+            const y = targetNode.position.y + NODE_HEIGHT / 2;
+            setTimeout(() => {
+              setCenter(x, y, { zoom: Math.max(getZoom(), 1), duration: 500 });
+            }, 0);
+          }
           return changed ? newNodes : nds;
         });
 
@@ -356,7 +383,7 @@ const GraphView = ({
     }, 300);
 
     return () => clearTimeout(timeout);
-  }, [searchString, nodes]);
+  }, [searchString, nodes, currentMatchIndex]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -399,7 +399,7 @@ const GraphView = ({
     <div
       ref={containerRef}
       tabIndex={0}
-      // onKeyDown={handleKeyDown}
+      onKeyDown={handleKeyDown}
       className="relative w-full h-full"
     >
       <ReactFlow

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -417,6 +417,8 @@ const GraphView = ({
         nodeTypes={nodeTypes}
         minZoom={0.05}
         maxZoom={5}
+        fitView
+        fitViewOptions={{ padding: 0.05, duration: 800 }}
         onEdgeMouseEnter={(_, edge) => setHoveredEdgeId(edge.id)}
         onEdgeMouseLeave={() => setHoveredEdgeId(null)}
         onPaneClick={() => {


### PR DESCRIPTION
## Summary

Fixes a bug where search results wouldn't update if the graph itself changed while you were searching.
Before, if the graph updated behind a search, the highlights would get stuck. Now, the search automatically refreshes whenever the graph changes, keeping the results accurate.

## What kind of change does this PR introduce

Bug fix

## Issue Number

Closes #244 

## Video


https://github.com/user-attachments/assets/9b0a214a-f625-4033-a71e-b80005353366



## Does this PR introduce a breaking change?

No

## If relevant, did you update the documentation?

Not required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now properly update when the schema is modified while search is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->