### PR TITLE
docs: update versioning section to reflect changesets workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,15 +210,15 @@ These issues will be addressed as time permits. If you encounter any other probl
 
 - Fork the repository
 
-```bash
-git clone https://github.com/ioflux-org/studio-json-schema.git
-```
+  ```bash
+  git clone https://github.com/ioflux-org/studio-json-schema.git
+  ```
 
 - Create a new branch
 
-```bash
-git checkout -b feature/my-feature
-```
+  ```bash
+  git checkout -b feature/my-feature
+  ```
 
 - Make your changes
 - Create a Pull Request
@@ -339,6 +339,13 @@ You do not need to generate a changeset if your PR only touches:
 - `.github/**` (CI/CD workflows)
 - `*.md` files (Documentation)
 - Internal tests or tooling not affecting the shipped application
+
+### Enforcement
+>
+> [!IMPORTANT]
+> Pull requests without a changeset file will be blocked by CI.
+>
+> This policy ensures all changes are properly versioned and that every integration remains clean, predictable, and traceable.
 
 ---
 


### PR DESCRIPTION
## Summary
Updates the versioning section to reflect the move to Changesets. Removes the old manual SemVer instructions.

## What kind of change does this PR introduce
Documentation

## Issue Number



Closes #246


## Screenshots/Video
<img width="1830" height="807" alt="Screenshot 2026-04-01 002938" src="https://github.com/user-attachments/assets/820680bc-4053-4f7e-ae68-fbfdf3ba2515" />

<!-- If relevant, add screenshots or videos demonstrating the change -->

## Does this PR introduce a breaking change?
No

## If relevant, did you update the documentation?

<!-- Yes or No, specify what was updated if yes -->
Yes — README.md 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced prior versioning guidance with a Changesets-based release process: instructions to create and commit changeset files, clarified when a changeset is not required, CI will enforce changeset presence, and TOC updated with new subsections.

* **Style**
  * Reformatted shell examples into fenced bash blocks, removed prompt artifacts, and normalized spacing and line breaks for clearer getting-started instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->