### PR TITLE
fix: use pull_request_target and github api to check changeset

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -74,7 +74,9 @@ jobs:
               issue_number
             });
             
-            const hasCommented = comments.data.some(c => c.body.includes(marker));
+            const hasCommented = comments.data.some(c => 
+              c.user.login === 'github-actions[bot]' && c.body.includes(marker)
+            );
             
             // Only comment if we haven't already
             if (!hasCommented) {

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -48,7 +48,8 @@ jobs:
               pull_number
             });
             
-            const changesetFiles = files.filter(f => f.filename.startsWith('.changeset/') && f.filename.endsWith('.md'));
+             const changesetFiles = files.filter(f =>  f.filename.startsWith('.changeset/') && f.filename.endsWith('.md') && f.filename !== '.changeset/README.md' );
+
             
             if (changesetFiles.length === 0) {
               core.setOutput('found', 'false');

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
-            const pull_number = context.issue.number;
+            const pull_number = context.payload.pull_request.number;
             
             // Fetch list of files changed in the PR
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -65,7 +65,7 @@ jobs:
           script: |
             const marker = '<!-- changeset-bot-comment -->';
             const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
+            const issue_number = context.payload.pull_request.number;
             
             // Fetch existing comments on the PR
             const comments = await github.rest.issues.listComments({

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -1,7 +1,7 @@
 name: Check Changeset
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
@@ -32,26 +32,31 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
-        if: steps.check-label.outputs.skip != 'true'
-        with:
-          fetch-depth: 0
-
       - name: Check for changeset
         id: check
         if: steps.check-label.outputs.skip != 'true'
-        run: |
-          CHANGED=$(git diff --name-only origin/main...HEAD | grep "^.changeset/.*\.md$" || true)
-
-          if [ -z "$CHANGED" ]; then
-            echo "found=false" >> "$GITHUB_OUTPUT"
-            echo "❌ No changeset found. Run 'npx changeset' locally to create one for your changes."
-            exit 1
-          else
-            echo "found=true" >> "$GITHUB_OUTPUT"
-            echo "✅ Changeset detected:"
-            echo "$CHANGED"
-          fi
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.issue.number;
+            
+            // Fetch list of files changed in the PR
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number
+            });
+            
+            const changesetFiles = files.filter(f => f.filename.startsWith('.changeset/') && f.filename.endsWith('.md'));
+            
+            if (changesetFiles.length === 0) {
+              core.setOutput('found', 'false');
+              core.setFailed("❌ No changeset found. Run 'npx changeset' locally to create one for your changes.");
+            } else {
+              core.setOutput('found', 'true');
+              console.log('✅ Changeset detected:\n' + changesetFiles.map(f => f.filename).join('\n'));
+            }
 
       - name: Comment on PR if missing
         if: failure() && steps.check.outputs.found == 'false'


### PR DESCRIPTION
### What this PR does
This PR fixes a bug where the `check-changeset.yml` workflow would silently fail when trying to comment on Pull Requests originating from outside forks.

### The Problem
When a Pull Request comes from an outside fork, GitHub Actions automatically downgrades the `GITHUB_TOKEN` to `read-only` to protect the repository from malicious PRs. Because of this restriction, the bot was receiving a `403 Forbidden` error when trying to use its token to post the "Changeset missing" comment, causing the workflow to silently skip commenting.

### The Solution (and securely)
To fix this while maintaining strict repo security, I made two major changes:
1. **Changed `pull_request` to `pull_request_target`**: This event forces the workflow to run in the trusted context of the base repository instead of the untrusted fork. This officially grants the action the necessary `write` permissions to post comments.
2. **Replaced `actions/checkout` with GitHub API**: Checking out untrusted fork code inside a `pull_request_target` action is a massive security risk. To make this bulletproof, I completely removed `actions/checkout` and the `git diff` bash command. Instead, the action now natively requests the modified file list using `actions/github-script` and the official GitHub API.

This new setup is much faster, immune to executing unverified fork code, and guarantees the Changeset Bot will always drop its comment correctly!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow trigger behavior and changed how changeset presence is detected by inspecting PR file list directly instead of using a repository checkout/diff.
  * Improved handling and reporting when changesets are missing, ensuring failures are surfaced clearly.
  * Corrected PR-number resolution for automated comments and tightened duplicate-comment checks to reduce redundant bot messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->