### PR TITLE
fix(ci): trigger deploy-preview on Release PR updates

### DIFF
--- a/.changeset/flat-llamas-serve.md
+++ b/.changeset/flat-llamas-serve.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": patch
+---
+
+Improve preview deployment workflow

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -38,8 +38,6 @@ jobs:
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           else
-            # For push events (like Changeset release branch updates), 
-            # find the PR associated with this branch.
             PR_NUMBER=$(gh pr list --head "${{ github.ref_name }}" --json number --jq '.[0].number')
             echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -5,10 +5,10 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches:
-      - changeset-release/**
+      - 'changeset-release/**'
 
 concurrency:
-  group: preview-build-${{ github.event.pull_request.number }}
+  group: preview-build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -32,8 +32,22 @@ jobs:
       - name: Build Site
         run: npm run build
 
+      - name: Determine PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            # For push events (like Changeset release branch updates), 
+            # find the PR associated with this branch.
+            PR_NUMBER=$(gh pr list --head "${{ github.ref_name }}" --json number --jq '.[0].number')
+            echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Save PR number
-        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+        run: echo "${{ steps.pr.outputs.number }}" > pr_number.txt
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -8,7 +8,7 @@ on:
       - 'changeset-release/**'
 
 concurrency:
-  group: preview-build-${{ github.event.pull_request.number || github.ref }}
+  group: preview-build-${{ github.event.pull_request.head.repo.full_name || github.repository }}
   cancel-in-progress: true
 
 jobs:
@@ -39,6 +39,10 @@ jobs:
             echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           else
             PR_NUMBER=$(gh pr list --head "${{ github.ref_name }}" --json number --jq '.[0].number')
+            if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
+              echo "::error::No open PR found for branch '${{ github.ref_name }}'"
+              exit 1
+            fi
             echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
           fi
         env:


### PR DESCRIPTION
Changes:

1.Updated Triggers: Added push event support for the changeset-release/** branch pattern in build-preview.yml.

2.Dynamic PR Identification: Added a step using GitHub CLI (gh pr list) to correctly identify the Pull Request number when the workflow is triggered by a push event.

3.Concurrency Optimization: Refined the concurrency group to use github.ref as a fallback, ensuring that multiple rapid updates to the same branch cancel previous redundant builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build preview workflow reliability by enhancing PR number detection across event types.
  * Tightened concurrency control to avoid undefined states and conflicts across different triggers.
  * Added a changeset to mark the json-schema-studio package for a patch release related to preview deployment improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->