### PR TITLE
feat: group Dependabot minor and patch updates to reduce PR noise

### DIFF
--- a/.changeset/shaky-peas-hug.md
+++ b/.changeset/shaky-peas-hug.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": patch
+---
+
+feat: group minor and patch Dependabot updates to reduce PR noise

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,20 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
       


### PR DESCRIPTION
## Summary

Configure Dependabot to group minor and patch dependency updates into single PRs per ecosystem (`npm` and `github-actions`), reducing PR noise while keeping major updates separate for individual review.

## What kind of change does this PR introduce

Enhancement — CI/CD configuration change. No code changes.

## Issue Number

Closes #280


Major version updates and security updates will continue to be opened as individual PRs.

## Does this PR introduce a breaking change?

No

## If relevant, did you update the documentation?

No 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to enhance stability by refining automatic update policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->