### PR TITLE
fix: reset search counter index when search string changes

### DIFF
--- a/.changeset/warm-mugs-clean.md
+++ b/.changeset/warm-mugs-clean.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": patch
+---
+
+search coutner resetting to valid index when search string changes

--- a/.changeset/warm-mugs-clean.md
+++ b/.changeset/warm-mugs-clean.md
@@ -2,4 +2,4 @@
 "json-schema-studio": patch
 ---
 
-search coutner resetting to valid index when search string changes
+search counter resetting to valid index when search string changes

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -314,7 +314,10 @@ const GraphView = ({
       setMatchedNodes(foundNodes);
 
       if (foundNodes.length > 0) {
-        const firstNode = foundNodes[currentMatchIndex % foundNodes.length];
+        const nextMatchIndex = 0;
+        setCurrentMatchIndex(nextMatchIndex);
+
+        const firstNode = foundNodes[nextMatchIndex];
         const x = firstNode.position.x + NODE_WIDTH / 2;
         const y = firstNode.position.y + NODE_HEIGHT / 2;
 


### PR DESCRIPTION
## Summary

This PR fixes a search bug where the match counter could show an invalid index after refining the search query (for example, 7/2).

The fix resets the active match index to the first valid result whenever the search results are recalculated, keeping:
- The counter accurate
- The highlighted node consistent with the counter
- Navigation behavior predictable after query changes

## What kind of change does this PR introduce

- Bug fix 
- UI/UX consistency

## Issue Number

<!-- Add issue number here -->

Closes #281 

## Video


https://github.com/user-attachments/assets/55722c1d-b520-4fed-b70a-4e88deb68d8c



## Does this PR introduce a breaking change?

No

## If relevant, did you update the documentation?

No, not required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed search counter to properly reset to a valid index when the search string changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->