### PR TITLE
feat: reposition search error toast to top-center

### DIFF
--- a/.changeset/tangy-words-flash.md
+++ b/.changeset/tangy-words-flash.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": patch
+---
+
+move "not in schema" error toast to top-center via React portal by preventing overlap with zoom controls on mobile and keeps the toast near the search bar on desktop.

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -404,11 +404,13 @@ const GraphView = ({
       )}
       {/*Error Message */}
       {errorMessage && showErrorPopup && createPortal(
-        <div className="fixed top-[120px] sm:top-[100px] left-1/2 -translate-x-1/2 flex gap-2 px-2 py-1 bg-red-500 text-white rounded-md shadow-lg z-[9999]">
+        <div role="alert" aria-live="assertive" aria-atomic="true" className="fixed top-[120px] sm:top-[100px] left-1/2 -translate-x-1/2 flex gap-2 px-2 py-1 bg-red-500 text-white rounded-md shadow-lg z-[9999]">
           <div className="text-sm font-medium tracking-wide font-roboto">
             {errorMessage}
           </div>
           <button
+            type="button"
+            aria-label="Close error"
             className="cursor-pointer"
             onClick={() => setShowErrorPopup(false)}
           >

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -6,6 +6,7 @@ import {
   useContext,
   useRef,
 } from "react";
+import { createPortal } from "react-dom";
 import { AppContext } from "../contexts/AppContext";
 import type { CompiledSchema } from "@hyperjump/json-schema/experimental";
 import "@xyflow/react/dist/style.css";
@@ -402,8 +403,8 @@ const GraphView = ({
         />
       )}
       {/*Error Message */}
-      {errorMessage && showErrorPopup && (
-        <div className="absolute bottom-[50px] left-[100px] flex gap-2 px-2 py-1 bg-red-500 text-white rounded-md shadow-lg">
+      {errorMessage && showErrorPopup && createPortal(
+        <div className="fixed top-[120px] sm:top-[100px] left-1/2 -translate-x-1/2 flex gap-2 px-2 py-1 bg-red-500 text-white rounded-md shadow-lg z-[9999]">
           <div className="text-sm font-medium tracking-wide font-roboto">
             {errorMessage}
           </div>
@@ -413,7 +414,8 @@ const GraphView = ({
           >
             <CgClose size={18} />
           </button>
-        </div>
+        </div>,
+        document.body
       )}
       {matchCount > 1 && (
         <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-0.5 bg-[var(--node-bg-color)] px-1.5 py-0.5 rounded border border-[var(--popup-border-color)] opacity-80 shadow-sm">


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Repositions the "not in schema" error toast from a fixed bottom-left position to a top-center portal-rendered toast. On **mobile**, the previous position overlapped with the zoom controls; on **desktop**, it appeared far from the search bar. The toast now renders via createPortal outside the ReactFlow DOM context with fixed positioning, keeping it visible and unobstructed on all screen sizes.


## What kind of change does this PR introduce

<!-- What kind of change is this? -->
Bug fix / UI improvement (no new features or breaking changes.)
## Issue Number

<!-- Add issue number here -->

Closes #261 

## Screenshots/Video

<!-- If relevant, add screenshots or videos demonstrating the change -->

https://github.com/user-attachments/assets/f3f0c478-d55a-491a-b416-3e9b0822b1be


## Does this PR introduce a breaking change?

<!-- Yes or No, and explain if yes -->
No
## If relevant, did you update the documentation?

<!-- Yes or No, specify what was updated if yes -->
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repositioned the "not in schema" error notification to the top-center to avoid overlapping mobile zoom controls while staying close to the search bar on desktop.
* **Accessibility**
  * Improved error popup accessibility and close control labeling for better screen reader support and clearer interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->