### PR TITLE
feat: add runtime validation for saved editor format

### DIFF
--- a/.changeset/runtime-format-validation.md
+++ b/.changeset/runtime-format-validation.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": patch
+---
+
+Add runtime validation for saved editor format value. The app now validates that sessionStorage format is either "json" or "yaml", auto-resets to "json" if invalid, and shows a one-time warning banner to inform the user.

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -133,11 +133,18 @@ const MonacoEditor = () => {
   useEffect(() => {
     if (showFormatWarning) {
       setShowFormatWarningPopup(true);
-      // Auto-dismiss popup after 5 seconds
-      const timer = setTimeout(() => setShowFormatWarningPopup(false), 5000);
-      return () => clearTimeout(timer);
     }
   }, [showFormatWarning]);
+
+  useEffect(() => {
+    if (!showFormatWarningPopup) return;
+
+    const timer = window.setTimeout(() => {
+      setShowFormatWarningPopup(false);
+    }, 5000);
+
+    return () => window.clearTimeout(timer);
+  }, [showFormatWarningPopup]);
 
   const toggleEditorVisibility = () => {
     if (!editorPanelRef.current) return;

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -96,7 +96,9 @@ const MonacoEditor = () => {
     schemaFormat,
     changeSchemaFormat,
     selectedNode,
-  } = useContext(AppContext);
+    showFormatWarning,
+  } =
+    useContext(AppContext);
 
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const editorPanelRef = useRef<ImperativePanelHandle>(null);
@@ -126,6 +128,16 @@ const MonacoEditor = () => {
 
   const [editorVisible, setEditorVisible] = useState(true);
   const [isAnimating, setIsAnimating] = useState(false);
+  const [showFormatWarningPopup, setShowFormatWarningPopup] = useState(false);
+
+  useEffect(() => {
+    if (showFormatWarning) {
+      setShowFormatWarningPopup(true);
+      // Auto-dismiss popup after 5 seconds
+      const timer = setTimeout(() => setShowFormatWarningPopup(false), 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [showFormatWarning]);
 
   const toggleEditorVisibility = () => {
     if (!editorPanelRef.current) return;
@@ -291,6 +303,38 @@ const MonacoEditor = () => {
       }`}
     >
       {isFullScreen && <NavigationBar />}
+      {showFormatWarning && (
+        <div className="bg-yellow-100 border-b border-yellow-300 px-4 py-2 text-sm text-yellow-800">
+          ⚠️ Invalid editor format detected in session storage. Resetting to JSON.
+        </div>
+      )}
+      {showFormatWarningPopup && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+          <div className="bg-yellow-50 border-2 border-yellow-300 rounded-lg p-6 max-w-md shadow-lg">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex-1">
+                <h3 className="font-semibold text-yellow-900 mb-2">Format Reset</h3>
+                <p className="text-yellow-800 text-sm">
+                  Invalid editor format was detected in your session storage and has been automatically reset to JSON. Your schema content has been preserved.
+                </p>
+              </div>
+              <button
+                onClick={() => setShowFormatWarningPopup(false)}
+                className="flex-shrink-0 text-yellow-600 hover:text-yellow-800 font-bold text-xl leading-none w-6 h-6 flex items-center justify-center"
+                aria-label="Close warning"
+              >
+                ✕
+              </button>
+            </div>
+            <button
+              onClick={() => setShowFormatWarningPopup(false)}
+              className="mt-4 w-full bg-yellow-200 hover:bg-yellow-300 text-yellow-900 font-medium py-2 px-4 rounded transition-colors"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
       <PanelGroup direction="horizontal">
         <Panel
           className="flex flex-col"

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -19,6 +19,7 @@ type AppContextType = {
 
   schemaFormat: SchemaFormat;
   changeSchemaFormat: (format: SchemaFormat) => void;
+  showFormatWarning: boolean;
 
   selectedNode: SelectedNode | null;
   setSelectedNode: (selectedNode: SelectedNode | null) => void;

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -15,6 +15,13 @@ import {
 export const AppProvider = ({ children }: { children: ReactNode }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isFullScreen, setIsFullScreen] = useState(false);
+  const persistedSchemaFormat = window.sessionStorage.getItem(
+    "ioflux.schema.editor.format"
+  );
+  const hasInvalidPersistedSchemaFormat =
+    !!persistedSchemaFormat &&
+    persistedSchemaFormat !== "json" &&
+    persistedSchemaFormat !== "yaml";
 
   const [theme, setTheme] = useState<"light" | "dark">(() => {
     const savedTheme = localStorage.getItem("theme");
@@ -24,10 +31,20 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       : "light";
   });
 
-  const [schemaFormat, setSchemaFormat] = useState<SchemaFormat>(
-    (window.sessionStorage.getItem(
-      "ioflux.schema.editor.format"
-    ) as SchemaFormat) ?? "json"
+  const [schemaFormat, setSchemaFormat] = useState<SchemaFormat>(() => {
+    if (persistedSchemaFormat === "json" || persistedSchemaFormat === "yaml") {
+      return persistedSchemaFormat;
+    }
+
+    if (persistedSchemaFormat) {
+      window.sessionStorage.setItem("ioflux.schema.editor.format", "json");
+    }
+
+    return "json";
+  });
+
+  const [showFormatWarning, setShowFormatWarning] = useState(
+    hasInvalidPersistedSchemaFormat
   );
 
   const toggleTheme = () => {
@@ -40,6 +57,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
 
   const changeSchemaFormat = (format: SchemaFormat) => {
     setSchemaFormat(format);
+    window.sessionStorage.setItem("ioflux.schema.editor.format", format);
   };
 
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
@@ -89,6 +107,16 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     document.documentElement.setAttribute("data-theme", theme);
   }, [theme]);
 
+  useEffect(() => {
+    if (!showFormatWarning) return;
+
+    const timer = window.setTimeout(() => {
+      setShowFormatWarning(false);
+    }, 5000);
+
+    return () => window.clearTimeout(timer);
+  }, [showFormatWarning]);
+
   const value = {
     containerRef,
     isFullScreen,
@@ -97,6 +125,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     toggleFullScreen,
     schemaFormat,
     changeSchemaFormat,
+    showFormatWarning,
     selectedNode,
     setSelectedNode,
     searchString,


### PR DESCRIPTION
## Summary

This PR adds runtime validation for the saved editor format value in session storage. If the stored value is invalid, the app resets it to `json` and shows a small yellow warning so the user knows what happened.

## Closes

Closes #293

## What changed

- Validates the saved editor format at runtime
- Resets invalid values like `xml` back to `json`
- Shows a yellow warning banner
- Shows a dismissible yellow popup for clearer feedback

## Screenshot

<img width="1901" height="867" alt="Screenshot 2026-04-06 222841" src="https://github.com/user-attachments/assets/a3522bc7-1209-438d-a0db-38a10e479c7a" />


## Notes

This keeps the app in a safe state even if session storage is manually edited or becomes invalid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime validation of the editor format setting: invalid values are automatically reset to JSON and users see a one-time warning.
  * Warning surfaces as an inline banner and a centered modal, which can be dismissed and auto-closes after ~5 seconds.

* **Bug Fixes**
  * Persisted format values are now validated on load to prevent invalid format states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->