### PR TITLE
fix: create fresh Dagre graph instance per layout call

### DIFF
--- a/.changeset/fix-dagre-singleton.md
+++ b/.changeset/fix-dagre-singleton.md
@@ -1,0 +1,14 @@
+---
+"json-schema-studio": patch
+---
+
+Fix Dagre graph singleton accumulating stale nodes across schema changes
+
+The module-level Dagre graph instance was persisting nodes/edges from previous
+schema compilations, causing layout corruption when switching between schemas with
+different property counts.
+
+- Move Dagre graph instantiation from module scope into getLayoutedElements function
+- Create fresh graph instance for each layout calculation
+- Prevent stale nodes from previous schemas affecting current layout
+- Improves graph rendering stability when working with multiple schemas

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -37,7 +37,6 @@ import { CgClose } from "react-icons/cg";
 import { extractKeywords } from "../utils/searchNodeHelpers";
 
 const nodeTypes = { customNode: CustomNode };
-const dagreGraph = new dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
 
 const NODE_WIDTH = 172;
 const NODE_HEIGHT = 36;
@@ -143,6 +142,10 @@ const GraphView = ({
 
   const getLayoutedElements = useCallback(
     (nodes: GraphNode[], edges: GraphEdge[], direction = "LR") => {
+      // Create a fresh Dagre graph instance for this layout calculation
+      // Prevents stale nodes from previous schemas corrupting the layout
+      const dagreGraph = new dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
+      
       const isHorizontal = direction === "LR";
       dagreGraph.setGraph({ rankdir: direction });
 


### PR DESCRIPTION
## Summary
Fixes stale Dagre graph singleton bug that corrupts graph layout when switching 
between schemas. The graph now gets created fresh for each layout calculation 
instead of reusing a module-level instance.

## What's Fixed
- ✅ Graph layout no longer corrupted when switching schemas
- ✅ Node positions recalculate cleanly  
- ✅ No ghost nodes from previous schemas
- ✅ Layout becomes deterministic and stable

## Technical Details
- Removed module-level `dagreGraph` singleton
- Create fresh instance in `getLayoutedElements()` function
- Each layout pass operates on clean graph state
- Zero behavior change visible to users (pure internal refactor)
## Img
<img width="1886" height="885" alt="Screenshot 2026-04-17 214255" src="https://github.com/user-attachments/assets/ce5a9259-4fbe-418a-a5b7-760cc5a923d9" />

## Testing
- Tested switching between schemas with different property counts
- Verified node positions recalculate correctly
- Confirmed no stale nodes persist after schema switch
- Build passes ✅
- No new linting errors ✅

This reopens the work from the previously closed PR #305.