### PR TITLE
feat(ci): link deploy-preview workflow status to corresponding PR

### DIFF
--- a/.changeset/khaki-beds-wink.md
+++ b/.changeset/khaki-beds-wink.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": minor
+---
+
+feat(ci): link deploy-preview workflow status to corresponding PR

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Save PR number
         run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
 
+      - name: Save PR head SHA
+        run: echo "${{ github.event.pull_request.head.sha }}" > pr_head_sha.txt
+
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
@@ -42,3 +45,4 @@ jobs:
           path: |
             dist
             pr_number.txt
+            pr_head_sha.txt

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           pr-number: ${{ steps.pr.outputs.pr_number }}
           message: |
-            ### ✅ Preview Deployed!
+            ### Preview Deployed!
 
             | Item | Status |
             | :--- | :--- |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -32,6 +32,36 @@ jobs:
           PR_NUMBER=$(cat artifact/pr_number.txt)
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
+      - name: Read PR head SHA
+        id: sha
+        run: |
+          PR_HEAD_SHA=$(cat artifact/pr_head_sha.txt)
+          echo "pr_head_sha=$PR_HEAD_SHA" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Deployment
+        id: deployment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: '${{ steps.sha.outputs.pr_head_sha }}',
+              environment: 'pr-preview-${{ steps.pr.outputs.pr_number }}',
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              description: 'PR Preview Deployment'
+            });
+            core.setOutput('deployment_id', deployment.data.id);
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: 'in_progress',
+              description: 'Deploying preview to Cloudflare Pages...'
+            });
+
       - name: Publish to Cloudflare Pages
         id: cloudflare_deploy
         uses: cloudflare/wrangler-action@v3
@@ -43,12 +73,41 @@ jobs:
             --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }}
             --branch=pr-${{ steps.pr.outputs.pr_number }}
 
+      - name: Set deployment status to success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.deployment_id }},
+              state: 'success',
+              environment_url: '${{ steps.cloudflare_deploy.outputs.pages-deployment-alias-url }}',
+              description: 'Preview deployed successfully'
+            });
+
+      - name: Set deployment status to failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.deployment_id }},
+              state: 'failure',
+              log_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+              description: 'Preview deployment failed'
+            });
+
       - name: Comment PR with Preview Link
+        if: success()
         uses: thollander/actions-comment-pull-request@v3
         with:
           pr-number: ${{ steps.pr.outputs.pr_number }}
           message: |
-            ### Preview Deployed!
+            ### ✅ Preview Deployed!
 
             | Item | Status |
             | :--- | :--- |
@@ -57,4 +116,21 @@ jobs:
             | **Action** | [View Logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
 
             _Last updated at ${{ github.event.workflow_run.updated_at }}_
-          comment-tag: preview_deploy_status # This ensures it updates the same comment instead of spamming
+          comment-tag: preview_deploy_status
+
+      - name: Comment PR with failure notice
+        if: failure()
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          pr-number: ${{ steps.pr.outputs.pr_number }}
+          message: |
+            ### ⚠️ Preview Deploy Failed!
+
+            | Item | Status |
+            | :--- | :--- |
+            | **Latest Deploy** | ❌ Failed |
+            | **Environment** | `Preview (PR-${{ steps.pr.outputs.pr_number }})` |
+            | **Action** | [View Logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
+
+            _Last updated at ${{ github.event.workflow_run.updated_at }}_
+          comment-tag: preview_deploy_status


### PR DESCRIPTION
## Summary

Links the `deploy-preview` workflow to its corresponding PR by using the GitHub Deployments API. Since `deploy-preview` runs via `workflow_run`, it never appeared in the PR's checks tab — meaning silent failures went unnoticed and stale preview links persisted. This PR creates a GitHub Deployment tied to the PR's head SHA, making the deploy status visible directly in the PR.

## What kind of change does this PR introduce

CI/CD enhancement — no application code changes.

## Issue Number

Closes #283

## Screenshots/Video

**Build PR Preview** — new `Save PR head SHA` step passing:
<img width="981" height="569" alt="image" src="https://github.com/user-attachments/assets/25ccf1cb-6584-4ad0-aa58-cbd8178dd776" />

> The deployment status in PR checks will be visible once tested against upstream with Cloudflare secrets configured.


## Does this PR introduce a breaking change?

No.

## If relevant, did you update the documentation?

No 
