### PR TITLE
feat: add ErrorPopup component and clear graph on schema errors

### DIFF
--- a/.changeset/loose-garlics-draw.md
+++ b/.changeset/loose-garlics-draw.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": minor
+---
+
+Feat: Added Error Popup

--- a/src/components/ErrorPopup.tsx
+++ b/src/components/ErrorPopup.tsx
@@ -1,0 +1,33 @@
+import { LuCircleAlert } from "react-icons/lu";
+import { MdClose } from "react-icons/md";
+
+const ErrorPopup = ({
+  message,
+  onClose,
+}: {
+  message: string;
+  onClose: () => void;
+}) => {
+  return (
+    <div className="flex items-start gap-2 px-3 py-2 rounded-lg bg-[var(--popup-bg-color)] border border-[var(--popup-border-color)] shadow-lg max-w-[300px]">
+      <LuCircleAlert className="text-red-500 flex-shrink-0 mt-0.5" size={18} />
+      <div className="flex flex-col gap-0.5 min-w-0">
+        <span className="text-xs font-semibold text-[var(--popup-text-color)]">
+          Error
+        </span>
+        <span className="text-xs text-[var(--popup-text-color)] opacity-80 break-words">
+          {message}
+        </span>
+      </div>
+      <button
+        onClick={onClose}
+        className="flex-shrink-0 text-[var(--popup-text-color)] opacity-60 hover:opacity-100 cursor-pointer"
+        aria-label="Dismiss error"
+      >
+        <MdClose size={16} />
+      </button>
+    </div>
+  );
+};
+
+export default ErrorPopup;

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -404,7 +404,7 @@ const GraphView = ({
         />
       )}
       {errorMessage && showErrorPopup && (
-        <div className="absolute bottom-[50px] left-[100px] flex gap-2 px-2 py-1 bg-red-500 text-white rounded-md shadow-lg">
+        <div className="absolute top-4 right-4 z-50 flex gap-2 px-2 py-1 bg-red-500 text-white rounded-md shadow-lg">
           <div className="text-sm font-medium tracking-wide font-roboto">
             {errorMessage}
           </div>

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -222,7 +222,12 @@ const GraphView = ({
   useEffect(() => {
     try {
       const result = generateNodesAndEdges(compiledSchema);
-      if (!result) return;
+      if (!result) {
+        setNodes([]);
+        setEdges([]);
+        setErrorMessage("");
+        return;
+      }
 
       const { nodes: rawNodes, edges: rawEdges } = result;
       const { nodes: layoutedNodes, edges: layoutedEdges } =
@@ -235,6 +240,8 @@ const GraphView = ({
       setCollisionResolved(false);
     } catch (err) {
       console.error("Error generating visualization graph: ", err);
+      setNodes([]);
+      setEdges([]);
     }
   }, [
     compiledSchema,
@@ -263,17 +270,7 @@ const GraphView = ({
     setCollisionResolved(true);
   }, [nodes, collisionResolved, allNodesMeasured, setNodes]);
 
-  useEffect(() => {
-    if (errorMessage) {
-      setShowErrorPopup(true);
-      const timer = setTimeout(() => {
-        setShowErrorPopup(false);
-      }, 3000);
-      return () => clearTimeout(timer);
-    } else {
-      setShowErrorPopup(false);
-    }
-  }, [errorMessage]);
+
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -352,6 +349,7 @@ const GraphView = ({
         setSelectedNode(null);
         fitView({ duration: 800, padding: 0.05 });
         setErrorMessage(`${trimmed} is not in schema`);
+        setShowErrorPopup(true);
       }
     }, 300);
 
@@ -406,7 +404,6 @@ const GraphView = ({
           }}
         />
       )}
-      {/*Error Message */}
       {errorMessage && showErrorPopup && (
         <div className="absolute bottom-[50px] left-[100px] flex gap-2 px-2 py-1 bg-red-500 text-white rounded-md shadow-lg">
           <div className="text-sm font-medium tracking-wide font-roboto">

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -271,7 +271,6 @@ const GraphView = ({
   }, [nodes, collisionResolved, allNodesMeasured, setNodes]);
 
 
-
   useEffect(() => {
     if (!containerRef.current) return;
 

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -1,5 +1,6 @@
 import { useContext, useState, useEffect, useRef } from "react";
 import { LuCircleAlert } from "react-icons/lu";
+import { Tooltip } from "react-tooltip";
 
 import { parseTree, findNodeAtLocation } from "jsonc-parser";
 import {
@@ -312,7 +313,7 @@ const MonacoEditor = () => {
         const browser = createBrowser(schemaId, schemaDocument);
       // The Hyperjump `getSchema` expects a full browser instance, but we only need the _cache
       // property for local-only resolution. This cast is safe because our usage only triggers cache lookup.
-      // @ts-expect-error: passing mocked browser object
+      // @ts-expect-error
       const schema = await getSchema(schemaDocument.baseUri, browser);
 
         setCompiledSchema(await compile(schema));
@@ -394,13 +395,14 @@ const MonacoEditor = () => {
             {schemaValidation.message}
           </div>
           {schemaValidation.status === "error" && (
-            <button
-              onClick={() => setShowErrorPopup(true)}
-              className="text-red-400 hover:text-red-300 cursor-pointer"
-              aria-label="Show error details"
-            >
-              <LuCircleAlert size={16} />
-            </button>
+              <button
+                onClick={() => setShowErrorPopup(true)}
+                className="text-red-400 hover:text-red-300 cursor-pointer"
+                aria-label="Show error details"
+                data-tooltip-id="error-details-tooltip"
+              >
+                <LuCircleAlert size={16} />
+              </button>
           )}
         </div>
       </div>
@@ -485,6 +487,14 @@ const MonacoEditor = () => {
             isMobile={true}
           />
         </div>
+      )}
+      {!showErrorPopup && (
+        <Tooltip
+          id="error-details-tooltip"
+          content="Show error details"
+          place="top"
+          style={{ fontSize: "12px", zIndex: 100 }}
+        />
       )}
     </div>
   );

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -1,4 +1,5 @@
 import { useContext, useState, useEffect, useRef } from "react";
+import { LuCircleAlert } from "react-icons/lu";
 
 import { parseTree, findNodeAtLocation } from "jsonc-parser";
 import {
@@ -24,6 +25,7 @@ import { AppContext, type SchemaFormat } from "../contexts/AppContext";
 import SchemaVisualization from "./SchemaVisualization";
 import NavigationBar from "./NavigationBar";
 import EditorToggleButton from "./EditorToggleButton";
+import ErrorPopup from "./ErrorPopup";
 import { parseSchema } from "../utils/parseSchema";
 import YAML from "js-yaml";
 import type { JSONSchema } from "@apidevtools/json-schema-ref-parser";
@@ -68,7 +70,7 @@ const getValidationUI = (theme: "light" | "dark") => ({
         : "text-amber-800 break-words",
   },
   error: {
-    message: "✗ ",
+    message: "✗ Invalid JSON Schema",
     className:
       theme === "dark"
         ? "text-red-400 break-words"
@@ -132,6 +134,8 @@ const MonacoEditor = () => {
 
   const [editorVisible, setEditorVisible] = useState(true);
   const [isAnimating, setIsAnimating] = useState(false);
+  const [showErrorPopup, setShowErrorPopup] = useState(false);
+  const [errorDetail, setErrorDetail] = useState("");
 
   const MOBILE_BREAKPOINT = 768;
   const [isMobile, setIsMobile] = useState(
@@ -308,10 +312,12 @@ const MonacoEditor = () => {
         const browser = createBrowser(schemaId, schemaDocument);
       // The Hyperjump `getSchema` expects a full browser instance, but we only need the _cache
       // property for local-only resolution. This cast is safe because our usage only triggers cache lookup.
-      // @ts-expect-error
+      // @ts-expect-error: passing mocked browser object
       const schema = await getSchema(schemaDocument.baseUri, browser);
 
         setCompiledSchema(await compile(schema));
+        setErrorDetail("");
+        setShowErrorPopup(false);
         setSchemaValidation(
           !dialect && typeof parsedSchema !== "boolean"
             ? {
@@ -328,9 +334,12 @@ const MonacoEditor = () => {
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
 
+        setCompiledSchema(null);
+        setErrorDetail(message);
+        setShowErrorPopup(true);
         setSchemaValidation({
           status: "error",
-          message: VALIDATION_UI["error"].message + message,
+          message: VALIDATION_UI["error"].message,
         });
       }
     }, 300);
@@ -378,11 +387,22 @@ const MonacoEditor = () => {
         role="status"
         aria-live="polite"
         aria-label={`Schema validation: ${schemaValidation.message}`}
-        className="shrink-0 px-2 py-1.5 bg-[var(--validation-bg-color)] text-sm"
+        className="shrink-0"
       >
-        <span className={VALIDATION_UI[schemaValidation.status].className}>
-          {schemaValidation.message}
-        </span>
+        <div className="flex items-center justify-between px-2 py-1.5 bg-[var(--validation-bg-color)] text-sm">
+          <div className={VALIDATION_UI[schemaValidation.status].className}>
+            {schemaValidation.message}
+          </div>
+          {schemaValidation.status === "error" && (
+            <button
+              onClick={() => setShowErrorPopup(true)}
+              className="text-red-400 hover:text-red-300 cursor-pointer"
+              aria-label="Show error details"
+            >
+              <LuCircleAlert size={16} />
+            </button>
+          )}
+        </div>
       </div>
     </Panel>
   );
@@ -393,6 +413,14 @@ const MonacoEditor = () => {
       className="flex flex-col relative bg-[var(--visualize-bg-color)]"
     >
       <SchemaVisualization compiledSchema={compiledSchema} />
+      {showErrorPopup && errorDetail && (
+        <div className="absolute top-2 left-12 z-10 animate-[fadeIn_200ms_ease-out]">
+          <ErrorPopup
+            message={errorDetail}
+            onClose={() => setShowErrorPopup(false)}
+          />
+        </div>
+      )}
     </Panel>
   );
 

--- a/src/style/theme.css
+++ b/src/style/theme.css
@@ -1,4 +1,4 @@
-﻿[data-theme="light"] {
+[data-theme="light"] {
   /* Backgrounds */
   --bg-color: #ffffff;
   --node-bg-color: #ffffff;
@@ -90,4 +90,15 @@
 
 .react-flow__pane {
   cursor: default !important;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }


### PR DESCRIPTION
## Summary

Adds an `ErrorPopup` component that displays schema parsing and visualization errors. When an error occurs, the graph visualization is cleared to avoid showing stale data. The popup persists until manually dismissed via the `×` button.
additionally added  a button in the Bottom area to reopen the popup, so users can view the error details again if they’ve closed it.

## What kind of change does this PR introduce

Feature — new `ErrorPopup` component and improved error handling in the visualization panel.



## Issue Number

Closes #108 

## Screenshots/Video



https://github.com/user-attachments/assets/20e1d629-6509-4fcd-97f4-68ebf276d82e






## Does this PR introduce a breaking change?

No.

## If relevant, did you update the documentation?

No. 