### PR TITLE
feat: Add ability to export schema visualization graph as an image

### DIFF
--- a/.changeset/export-graph.md
+++ b/.changeset/export-graph.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": minor
+---
+
+feat: add ability to export schema visualization graph as an image

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@monaco-editor/react": "^4.7.0",
         "@tailwindcss/vite": "^4.1.10",
         "@xyflow/react": "^12.8.3",
+        "html-to-image": "^1.11.13",
         "js-yaml": "^4.1.1",
         "jsonc-parser": "^3.3.1",
         "monaco-editor": "^0.52.2",
@@ -2830,6 +2831,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/idn-hostname": {
       "version": "15.1.8",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@tailwindcss/vite": "^4.1.10",
     "@xyflow/react": "^12.8.3",
+    "html-to-image": "^1.11.13",
     "js-yaml": "^4.1.1",
     "jsonc-parser": "^3.3.1",
     "monaco-editor": "^0.52.2",

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -385,7 +385,7 @@ const GraphView = ({
 
     if (viewportNode) {
       toPng(viewportNode, {
-        backgroundColor: theme === "dark" ? "#1e1e1e" : "#ffffff",
+        backgroundColor: getComputedStyle(document.documentElement).getPropertyValue("--visualize-bg-color").trim(),
         width: imageWidth,
         height: imageHeight,
         style: {

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -327,9 +327,9 @@ const GraphView = ({
         searchWords.length === 0
           ? []
           : nodes.filter((node) => {
-            const titleKeyWords = extractKeywords(node.data.nodeLabel);
-            return searchWords.every((word) => titleKeyWords.includes(word));
-          });
+              const titleKeyWords = extractKeywords(node.data.nodeLabel);
+              return searchWords.every((word) => titleKeyWords.includes(word));
+            });
 
       setMatchedNodes(foundNodes);
 

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -11,7 +11,6 @@ import type { CompiledSchema } from "@hyperjump/json-schema/experimental";
 import "@xyflow/react/dist/style.css";
 import dagre from "@dagrejs/dagre";
 import { toPng } from "html-to-image";
-import { BsDownload } from "react-icons/bs";
 import {
   ReactFlow,
   Background,
@@ -21,7 +20,6 @@ import {
   Position,
   BackgroundVariant,
   useReactFlow,
-  Panel,
   getNodesBounds,
   getViewportForBounds,
   type NodeMouseHandler,
@@ -53,7 +51,7 @@ const GraphView = ({
   compiledSchema: CompiledSchema | null;
 }) => {
   const { setCenter, getZoom, fitView, getNodes } = useReactFlow();
-  const { theme, selectedNode, setSelectedNode, searchString, registerNavigateMatch } =
+  const { theme, selectedNode, setSelectedNode, searchString, registerNavigateMatch, registerExportGraph } =
     useContext(AppContext);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -329,9 +327,9 @@ const GraphView = ({
         searchWords.length === 0
           ? []
           : nodes.filter((node) => {
-              const titleKeyWords = extractKeywords(node.data.nodeLabel);
-              return searchWords.every((word) => titleKeyWords.includes(word));
-            });
+            const titleKeyWords = extractKeywords(node.data.nodeLabel);
+            return searchWords.every((word) => titleKeyWords.includes(word));
+          });
 
       setMatchedNodes(foundNodes);
 
@@ -404,6 +402,10 @@ const GraphView = ({
     }
   }, [getNodes, theme]);
 
+  useEffect(() => {
+    registerExportGraph(onDownload);
+  }, [onDownload, registerExportGraph]);
+
   return (
     <div
       ref={containerRef}
@@ -442,16 +444,6 @@ const GraphView = ({
           color="var(--reactflow-bg-sub-pattern-color)"
         />
         <Controls />
-        <Panel position="top-right">
-          <button
-            className="flex items-center gap-2 bg-[var(--popup-header-bg-color)] border border-[var(--popup-border-color)] text-[var(--navigation-text-color)] px-3 py-1.5 rounded shadow hover:opacity-80 transition-opacity cursor-pointer"
-            onClick={onDownload}
-            aria-label="Download Image"
-          >
-            <BsDownload />
-            <span className="text-sm font-medium">Export Image</span>
-          </button>
-        </Panel>
       </ReactFlow>
 
       {selectedNode?.data && (

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -10,6 +10,8 @@ import { AppContext } from "../contexts/AppContext";
 import type { CompiledSchema } from "@hyperjump/json-schema/experimental";
 import "@xyflow/react/dist/style.css";
 import dagre from "@dagrejs/dagre";
+import { toPng } from "html-to-image";
+import { BsDownload } from "react-icons/bs";
 import {
   ReactFlow,
   Background,
@@ -19,6 +21,9 @@ import {
   Position,
   BackgroundVariant,
   useReactFlow,
+  Panel,
+  getNodesBounds,
+  getViewportForBounds,
   type NodeMouseHandler,
 } from "@xyflow/react";
 
@@ -47,8 +52,8 @@ const GraphView = ({
 }: {
   compiledSchema: CompiledSchema | null;
 }) => {
-  const { setCenter, getZoom, fitView } = useReactFlow();
-  const { selectedNode, setSelectedNode, searchString, registerNavigateMatch } =
+  const { setCenter, getZoom, fitView, getNodes } = useReactFlow();
+  const { theme, selectedNode, setSelectedNode, searchString, registerNavigateMatch } =
     useContext(AppContext);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -361,6 +366,44 @@ const GraphView = ({
 
     return () => clearTimeout(timeout);
   }, [searchString]);
+
+  const onDownload = useCallback(() => {
+    const nodesBounds = getNodesBounds(getNodes());
+    const imageWidth = nodesBounds.width + 100;
+    const imageHeight = nodesBounds.height + 100;
+
+    const viewport = getViewportForBounds(
+      nodesBounds,
+      imageWidth,
+      imageHeight,
+      0.5,
+      2,
+      0.1
+    );
+
+    const viewportNode = document.querySelector(
+      ".react-flow__viewport"
+    ) as HTMLElement;
+
+    if (viewportNode) {
+      toPng(viewportNode, {
+        backgroundColor: theme === "dark" ? "#1e1e1e" : "#ffffff",
+        width: imageWidth,
+        height: imageHeight,
+        style: {
+          width: `${imageWidth}px`,
+          height: `${imageHeight}px`,
+          transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
+        },
+      }).then((dataUrl) => {
+        const a = document.createElement("a");
+        a.setAttribute("download", "schema-graph.png");
+        a.setAttribute("href", dataUrl);
+        a.click();
+      });
+    }
+  }, [getNodes, theme]);
+
   return (
     <div
       ref={containerRef}
@@ -399,6 +442,16 @@ const GraphView = ({
           color="var(--reactflow-bg-sub-pattern-color)"
         />
         <Controls />
+        <Panel position="top-right">
+          <button
+            className="flex items-center gap-2 bg-[var(--popup-header-bg-color)] border border-[var(--popup-border-color)] text-[var(--navigation-text-color)] px-3 py-1.5 rounded shadow hover:opacity-80 transition-opacity cursor-pointer"
+            onClick={onDownload}
+            aria-label="Download Image"
+          >
+            <BsDownload />
+            <span className="text-sm font-medium">Export Image</span>
+          </button>
+        </Panel>
       </ReactFlow>
 
       {selectedNode?.data && (

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -370,7 +370,7 @@ const MonacoEditor = () => {
       onDragOver={handleDragOver}
       onDrop={handleDrop}
     >
-      <div className="flex items-center gap-2 px-2 py-1 bg-[var(--validation-bg-color)]">
+      <div className="flex items-center gap-2 px-2 py-1 bg-[var(--validation-bg-color)] border-b border-[var(--popup-border-color)]">
           <input
             type="file"
             id="schema-file-input"
@@ -381,19 +381,23 @@ const MonacoEditor = () => {
           />
           <div className="ml-auto flex items-center gap-3">
             <button
-              className="text-lg cursor-pointer"
               onClick={() => fileInputRef.current?.click()}
-              data-tooltip-id="upload-file-editor"
+              className="h-[26px] flex items-center gap-1.5 bg-[var(--bg-color)] border border-[var(--popup-border-color)] text-[var(--text-color)] text-sm px-1.5 rounded-sm hover:opacity-75 transition-opacity cursor-pointer"
               aria-label="Upload JSON/YAML schema file"
-              title="Upload JSON/YAML schema file"
+              title="Upload JSON/YAML (or drag & drop)"
             >
-              <BsUpload className="text-[var(--text-color)]" />
+              <BsUpload size={12} />
+              <span>Upload</span>
             </button>
-            <Tooltip
-              id="upload-file-editor"
-              content="Upload JSON/YAML (or drag & drop)"
-              style={{ fontSize: "10px", zIndex: 100 }}
-            />
+            <button
+              onClick={triggerExportGraph}
+              className="h-[26px] flex items-center gap-1.5 bg-[var(--bg-color)] border border-[var(--popup-border-color)] text-[var(--text-color)] text-sm px-1.5 rounded-sm hover:opacity-75 transition-opacity cursor-pointer"
+              aria-label="Export graph as image"
+              title="Export graph as image"
+            >
+              <BsDownload size={12} />
+              <span>Export</span>
+            </button>
             <label htmlFor="schema-format-select" className="sr-only">
               Schema format
             </label>
@@ -401,20 +405,11 @@ const MonacoEditor = () => {
               id="schema-format-select"
               value={schemaFormat}
               onChange={(e) => changeSchemaFormat(e.target.value as SchemaFormat)}
-              className="flex-shrink-0 bg-[var(--bg-color)] text-[var(--text-color)] text-sm outline-none cursor-pointer border border-[var(--popup-border-color)] rounded-sm"
+              className="h-[26px] min-w-[60px] px-1 flex-shrink-0 bg-[var(--bg-color)] text-[var(--text-color)] text-sm outline-none cursor-pointer border border-[var(--popup-border-color)] rounded-sm"
             >
               <option value="json">JSON</option>
               <option value="yaml">YAML</option>
             </select>
-            <button
-              onClick={triggerExportGraph}
-              className="flex items-center gap-1.5 bg-[var(--bg-color)] border border-[var(--popup-border-color)] text-[var(--text-color)] text-sm px-2 py-0.5 rounded-sm hover:opacity-75 transition-opacity cursor-pointer"
-              aria-label="Export graph as image"
-              title="Export graph as image"
-            >
-              <BsDownload size={12} />
-              <span>Export</span>
-            </button>
           </div>
         </div>
       <div className="flex-1 min-h-0">

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -1,6 +1,5 @@
 import { useContext, useState, useEffect, useRef } from "react";
 import { BsUpload, BsDownload } from "react-icons/bs";
-import { Tooltip } from "react-tooltip";
 import { SESSION_SCHEMA_KEY } from "../constants";
 
 import {

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -1,5 +1,5 @@
 import { useContext, useState, useEffect, useRef } from "react";
-import { BsUpload } from "react-icons/bs";
+import { BsUpload, BsDownload } from "react-icons/bs";
 import { Tooltip } from "react-tooltip";
 import { SESSION_SCHEMA_KEY } from "../constants";
 
@@ -92,6 +92,7 @@ const MonacoEditor = () => {
     selectedNode,
     schemaText,
     setSchemaText,
+    triggerExportGraph,
   } = useContext(AppContext);
 
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
@@ -369,7 +370,7 @@ const MonacoEditor = () => {
       onDragOver={handleDragOver}
       onDrop={handleDrop}
     >
-        <div className="flex items-center gap-2 px-2 py-1 bg-[var(--validation-bg-color)]">
+      <div className="flex items-center gap-2 px-2 py-1 bg-[var(--validation-bg-color)]">
           <input
             type="file"
             id="schema-file-input"
@@ -405,6 +406,15 @@ const MonacoEditor = () => {
               <option value="json">JSON</option>
               <option value="yaml">YAML</option>
             </select>
+            <button
+              onClick={triggerExportGraph}
+              className="flex items-center gap-1.5 bg-[var(--bg-color)] border border-[var(--popup-border-color)] text-[var(--text-color)] text-sm px-2 py-0.5 rounded-sm hover:opacity-75 transition-opacity cursor-pointer"
+              aria-label="Export graph as image"
+              title="Export graph as image"
+            >
+              <BsDownload size={12} />
+              <span>Export</span>
+            </button>
           </div>
         </div>
       <div className="flex-1 min-h-0">

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -31,6 +31,9 @@ type AppContextType = {
 
   registerNavigateMatch: (fn: (dir: NavigationDirection) => void) => void;
   triggerNavigateMatch: (dir: NavigationDirection) => void;
+
+  registerExportGraph: (fn: () => void) => void;
+  triggerExportGraph: () => void;
 };
 
 export const AppContext = createContext<AppContextType>({} as AppContextType);

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -94,6 +94,16 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     navigateMatchRef.current?.(dir);
   };
 
+  const exportGraphRef = useRef<(() => void) | null>(null);
+
+  const registerExportGraph = (fn: () => void) => {
+    exportGraphRef.current = fn;
+  };
+
+  const triggerExportGraph = () => {
+    exportGraphRef.current?.();
+  };
+
   const toggleFullScreen = useCallback(() => {
     const el = containerRef.current;
 
@@ -142,6 +152,8 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     setSearchString,
     registerNavigateMatch,
     triggerNavigateMatch,
+    registerExportGraph,
+    triggerExportGraph,
   };
 
   return <AppContext.Provider value={value}>{children}</AppContext.Provider>;


### PR DESCRIPTION
### Summary
This PR enables users to download and share their generated JSON/YAML schema visualizations. It introduces an "Export Image" button directly inside the React Flow canvas, allowing users to save the current graph layout as a high-quality `.png` file.

##Closes #341 

### Key Changes
* **Image Export Functionality:** Integrated `html-to-image` to capture the `.react-flow__viewport` node and convert it into a downloadable PNG file.
* **Canvas Export Button:** Added a new `Panel` in `GraphView.tsx` (positioned top-right) with an "Export Image" button using the `BsDownload` icon.
* **Smart Bounding & Padding:** Leveraged React Flow's `getNodesBounds` and `getViewportForBounds` to calculate the exact dimensions of the visible nodes before exporting.