### PR TITLE
feat: implement dependentSchemas keyword handler for graph visualization

### DIFF
--- a/.changeset/dependent-schemas-handler.md
+++ b/.changeset/dependent-schemas-handler.md
@@ -1,0 +1,7 @@
+---
+"json-schema-studio": minor
+---
+
+Implement `dependentSchemas` keyword handler in graph visualization
+
+Properties with `dependentSchemas` now render as connected child nodes in the graph, making schema dependencies visually explorable.

--- a/src/utils/processAST.ts
+++ b/src/utils/processAST.ts
@@ -351,7 +351,13 @@ const keywordHandlerMap: KeywordHandlerMap = {
         }
         return { key: "patternProperties", data: { value: getArrayFromNumber(value.length) } }
     },
-    // "https://json-schema.org/keyword/dependentSchemas": createBasicKeywordHandler("dependentSchemas"),
+    "https://json-schema.org/keyword/dependentSchemas": (ast, keywordValue, nodes, edges, parentId, nodeDepth, renderedNodes) => {
+        const value = keywordValue as [string, string][];
+        for (const [propertyName, schemaUri] of value) {
+            processAST({ ast, schemaUri, nodes, edges, parentId, renderedNodes, childId: propertyName, nodeTitle: `dependentSchemas["${propertyName}"]`, nodeDepth });
+        }
+        return { key: "dependentSchemas", data: { value: value.map(([propertyName]) => propertyName) } };
+    },
     "https://json-schema.org/keyword/contains": (ast, keywordValue, nodes, edges, parentId, nodeDepth, renderedNodes) => {
         const value = keywordValue as { contains: string; minContains: number; maxContains: number };
         processAST({ ast, schemaUri: value.contains, nodes, edges, parentId, childId: "contains", renderedNodes, nodeTitle: "contains", nodeDepth });


### PR DESCRIPTION
## Summary

`dependentSchemas` is a JSON Schema keyword that allows you to define a sub-schema that must be valid when a specific property is present. Previously, this keyword was commented out in the graph visualizer, so schemas using `dependentSchemas` were silently ignored in the graph output.

## What Changed

- **`src/utils/processAST.ts`**: Implemented a proper handler for the `https://json-schema.org/keyword/dependentSchemas` keyword. The handler iterates over each `[propertyName, schemaUri]` pair in the keyword's value and recursively calls `processAST` for each dependent sub-schema — consistent with how other structural keywords like `properties`, `patternProperties`, and `prefixItems` are handled.

<img width="1344" height="445" alt="image" src="https://github.com/user-attachments/assets/92033079-2778-4af1-8eed-af2fb36a3877" />
