### PR TITLE
fix: handle multi-type schemas in node type inference

### DIFF
--- a/.changeset/multi-type-schema-support.md
+++ b/.changeset/multi-type-schema-support.md
@@ -1,0 +1,7 @@
+---
+"json-schema-studio": patch
+---
+
+Fix: Handle multi-type schemas in node type inference
+
+Multi-type schemas (like `["string", "null"]`) were previously failing type inference and falling back to a default "others" node style. The type inference logic has been updated to pick the first non-null type from the array to determine the node's visual style.

--- a/src/components/CustomReactFlowNode.tsx
+++ b/src/components/CustomReactFlowNode.tsx
@@ -1,6 +1,5 @@
 import { Handle } from "@xyflow/react";
 import type { RFNodeData } from "../utils/processAST";
-import { neonColors } from "../utils/processAST";
 import { useContext, useLayoutEffect, useRef, useState } from "react";
 import { AppContext } from "../contexts/AppContext";
 
@@ -79,7 +78,12 @@ const CustomNode = ({ data, id, selected }: { data: RFNodeData; id: string; sele
 
       <div className="flex flex-col">
         {Object.entries(data.nodeData).map(([key, keyData]) => {
-          const isArray = Array.isArray(keyData.value);
+          const isTypeColorMap =
+            key === "type" &&
+            typeof keyData.value === "object" &&
+            keyData.value !== null &&
+            !Array.isArray(keyData.value);
+          const isArray = !isTypeColorMap && Array.isArray(keyData.value);
 
           return (
             <div
@@ -97,29 +101,44 @@ const CustomNode = ({ data, id, selected }: { data: RFNodeData; id: string; sele
                 {!data.isBooleanNode && `${key}:`}
               </span>
 
-              {isArray ? (
+              {isTypeColorMap ? (
                 <div className="flex-col w-full gap-1 flex py-1">
-                  {(keyData.value as string[]).map((item, index) => {
-                    const itemColor = key === "type" && item in neonColors
-                      ? neonColors[item as keyof typeof neonColors]
-                      : null;
-                    return (
-                      <div
-                        ref={(el) => {
-                          rowRefs.current[`${id}-${item}`] = el;
-                        }}
-                        key={index}
-                        className={`px-2 py-[2px] ${itemColor ? "rounded text-center font-medium shadow-sm" : "bg-[var(--node-value-bg-color)]"}`}
-                        style={{
-                          border: itemColor ? `1px solid ${itemColor}` : `1px solid ${color}30`,
-                          backgroundColor: itemColor ? `${itemColor}33` : undefined,
-                          color: itemColor ? (theme === "dark" ? itemColor : `color-mix(in srgb, ${itemColor} 60%, black)`) : undefined,
-                        }}
-                      >
-                        {item}
-                      </div>
-                    );
-                  })}
+                  {Object.entries(
+                    keyData.value as Record<string, string>
+                  ).map(([typeName, itemColor]) => (
+                    <div
+                      ref={(el) => {
+                        rowRefs.current[`${id}-${typeName}`] = el;
+                      }}
+                      key={typeName}
+                      className="px-2 py-[2px] rounded text-center font-medium shadow-sm"
+                      style={{
+                        border: `1px solid ${itemColor}`,
+                        backgroundColor: `${itemColor}33`,
+                        color:
+                          theme === "dark"
+                            ? itemColor
+                            : `color-mix(in srgb, ${itemColor} 60%, black)`,
+                      }}
+                    >
+                      {typeName}
+                    </div>
+                  ))}
+                </div>
+              ) : isArray ? (
+                <div className="flex-col w-full gap-1 flex py-1">
+                  {(keyData.value as string[]).map((item, index) => (
+                    <div
+                      ref={(el) => {
+                        rowRefs.current[`${id}-${item}`] = el;
+                      }}
+                      key={index}
+                      className="px-2 py-[2px] bg-[var(--node-value-bg-color)]"
+                      style={{ border: `1px solid ${color}30` }}
+                    >
+                      {item}
+                    </div>
+                  ))}
                 </div>
               ) : (
                 <span
@@ -133,6 +152,7 @@ const CustomNode = ({ data, id, selected }: { data: RFNodeData; id: string; sele
             </div>
           );
         })}
+
       </div>
 
       {data.sourceHandles.map(({ handleId, position }) => (

--- a/src/components/CustomReactFlowNode.tsx
+++ b/src/components/CustomReactFlowNode.tsx
@@ -3,7 +3,15 @@ import type { RFNodeData } from "../utils/processAST";
 import { useContext, useLayoutEffect, useRef, useState } from "react";
 import { AppContext } from "../contexts/AppContext";
 
-const CustomNode = ({ data, id, selected }: { data: RFNodeData; id: string; selected: boolean }) => {
+const CustomNode = ({
+  data,
+  id,
+  selected,
+}: {
+  data: RFNodeData;
+  id: string;
+  selected: boolean;
+}) => {
   const { theme } = useContext(AppContext);
 
   const rowRefs = useRef<
@@ -35,14 +43,18 @@ const CustomNode = ({ data, id, selected }: { data: RFNodeData; id: string; sele
   return (
     <div
       className={`
-        ${data.isBooleanNode
-          ? "rounded-2xl text-center overflow-hidden"
-          : "rounded"
+        ${
+          data.isBooleanNode
+            ? "rounded-2xl text-center overflow-hidden"
+            : "rounded"
         }
         relative transition-shadow duration-300 text-sm bg-[var(--node-bg-color)] text-[var(--text-color)]
         min-w-[100px] max-w-[400px] hover:shadow-[0_0_10px_var(--color)]
-        ${/* Change 25: Apply visual highlighting (shadow and ring) when node is selected */ ""}
-        ${selected ? "shadow-[0_0_15px_var(--color)] ring-2 ring-[var(--color)]" : ""}
+        ${
+          selected
+            ? "shadow-[0_0_15px_var(--color)] ring-2 ring-[var(--color)]"
+            : ""
+        }
       `}
       style={{
         ["--color" as string]: color,
@@ -103,27 +115,27 @@ const CustomNode = ({ data, id, selected }: { data: RFNodeData; id: string; sele
 
               {isTypeColorMap ? (
                 <div className="flex-col w-full gap-1 flex py-1">
-                  {Object.entries(
-                    keyData.value as Record<string, string>
-                  ).map(([typeName, itemColor]) => (
-                    <div
-                      ref={(el) => {
-                        rowRefs.current[`${id}-${typeName}`] = el;
-                      }}
-                      key={typeName}
-                      className="px-2 py-[2px] rounded text-center font-medium shadow-sm"
-                      style={{
-                        border: `1px solid ${itemColor}`,
-                        backgroundColor: `${itemColor}33`,
-                        color:
-                          theme === "dark"
-                            ? itemColor
-                            : `color-mix(in srgb, ${itemColor} 60%, black)`,
-                      }}
-                    >
-                      {typeName}
-                    </div>
-                  ))}
+                  {Object.entries(keyData.value as Record<string, string>).map(
+                    ([typeName, itemColor]) => (
+                      <div
+                        ref={(el) => {
+                          rowRefs.current[`${id}-${typeName}`] = el;
+                        }}
+                        key={typeName}
+                        className="px-2 py-[2px] rounded text-center font-medium shadow-sm"
+                        style={{
+                          border: `1px solid ${itemColor}`,
+                          backgroundColor: `${itemColor}33`,
+                          color:
+                            theme === "dark"
+                              ? itemColor
+                              : `color-mix(in srgb, ${itemColor} 60%, black)`,
+                        }}
+                      >
+                        {typeName}
+                      </div>
+                    )
+                  )}
                 </div>
               ) : isArray ? (
                 <div className="flex-col w-full gap-1 flex py-1">
@@ -152,7 +164,6 @@ const CustomNode = ({ data, id, selected }: { data: RFNodeData; id: string; sele
             </div>
           );
         })}
-
       </div>
 
       {data.sourceHandles.map(({ handleId, position }) => (

--- a/src/components/CustomReactFlowNode.tsx
+++ b/src/components/CustomReactFlowNode.tsx
@@ -1,5 +1,6 @@
 import { Handle } from "@xyflow/react";
 import type { RFNodeData } from "../utils/processAST";
+import { neonColors } from "../utils/processAST";
 import { useContext, useLayoutEffect, useRef, useState } from "react";
 import { AppContext } from "../contexts/AppContext";
 
@@ -30,13 +31,14 @@ const CustomNode = ({ data, id, selected }: { data: RFNodeData; id: string; sele
     setHandleOffsets(offsets);
   }, [data.nodeData]);
 
+  const { color } = data.nodeStyle;
+
   return (
     <div
       className={`
-        ${
-          data.isBooleanNode
-            ? "rounded-2xl text-center overflow-hidden"
-            : "rounded"
+        ${data.isBooleanNode
+          ? "rounded-2xl text-center overflow-hidden"
+          : "rounded"
         }
         relative transition-shadow duration-300 text-sm bg-[var(--node-bg-color)] text-[var(--text-color)]
         min-w-[100px] max-w-[400px] hover:shadow-[0_0_10px_var(--color)]
@@ -44,11 +46,11 @@ const CustomNode = ({ data, id, selected }: { data: RFNodeData; id: string; sele
         ${selected ? "shadow-[0_0_15px_var(--color)] ring-2 ring-[var(--color)]" : ""}
       `}
       style={{
-        ["--color" as string]: data.nodeStyle.color,
+        ["--color" as string]: color,
         border:
           theme === "dark"
-            ? `1px solid ${data.nodeStyle.color}`
-            : `1px solid color-mix(in srgb, ${data.nodeStyle.color} 80%, black)`,
+            ? `1px solid ${color}`
+            : `1px solid color-mix(in srgb, ${color} 80%, black)`,
         wordBreak: "break-word",
       }}
     >
@@ -64,12 +66,12 @@ const CustomNode = ({ data, id, selected }: { data: RFNodeData; id: string; sele
       <div
         className="px-2 font-semibold"
         style={{
-          background: `${data.nodeStyle.color}50`,
-          borderBottom: `1px solid ${data.nodeStyle.color}`,
+          background: `${color}50`,
+          borderBottom: `1px solid ${color}`,
           color:
             theme === "dark"
-              ? data.nodeStyle.color
-              : `color-mix(in srgb, ${data.nodeStyle.color} 60%, black)`,
+              ? color
+              : `color-mix(in srgb, ${color} 60%, black)`,
         }}
       >
         {data.nodeLabel}
@@ -96,19 +98,28 @@ const CustomNode = ({ data, id, selected }: { data: RFNodeData; id: string; sele
               </span>
 
               {isArray ? (
-                <div className="flex-col w-full">
-                  {(keyData.value as string[]).map((item, index) => (
-                    <div
-                      ref={(el) => {
-                        rowRefs.current[`${id}-${item}`] = el;
-                      }}
-                      key={index}
-                      className="px-2 py-[2px] bg-[var(--node-value-bg-color)]"
-                      style={{ border: `1px solid ${data.nodeStyle.color}30` }}
-                    >
-                      {item}
-                    </div>
-                  ))}
+                <div className="flex-col w-full gap-1 flex py-1">
+                  {(keyData.value as string[]).map((item, index) => {
+                    const itemColor = key === "type" && item in neonColors
+                      ? neonColors[item as keyof typeof neonColors]
+                      : null;
+                    return (
+                      <div
+                        ref={(el) => {
+                          rowRefs.current[`${id}-${item}`] = el;
+                        }}
+                        key={index}
+                        className={`px-2 py-[2px] ${itemColor ? "rounded text-center font-medium shadow-sm" : "bg-[var(--node-value-bg-color)]"}`}
+                        style={{
+                          border: itemColor ? `1px solid ${itemColor}` : `1px solid ${color}30`,
+                          backgroundColor: itemColor ? `${itemColor}33` : undefined,
+                          color: itemColor ? (theme === "dark" ? itemColor : `color-mix(in srgb, ${itemColor} 60%, black)`) : undefined,
+                        }}
+                      >
+                        {item}
+                      </div>
+                    );
+                  })}
                 </div>
               ) : (
                 <span

--- a/src/utils/inferSchemaType.ts
+++ b/src/utils/inferSchemaType.ts
@@ -37,9 +37,22 @@ const refKeyword = new Set([
     "$ref"
 ]);
 
-export const inferSchemaType = (nodeData: GraphNode["data"]["nodeData"]): [string, string] => {
-    if (typeof nodeData.type?.value === "string") {
-        return ["objectSchema", nodeData.type.value as string];
+export const inferSchemaType = (nodeData: GraphNode["data"]["nodeData"]): [string, string, string[]?] => {
+    const typeValue = nodeData.type?.value;
+
+    if (typeof typeValue === "string") {
+        return ["objectSchema", typeValue];
+    }
+
+    if (Array.isArray(typeValue)) {
+        let primaryType = "others";
+        for (const t of typeValue as string[]) {
+            if (t !== "null") {
+                primaryType = t;
+                break;
+            }
+        }
+        return ["multiType", primaryType, typeValue as string[]];
     }
 
     const hasAnyKeyword = (keywords: Set<string>) => {

--- a/src/utils/inferSchemaType.ts
+++ b/src/utils/inferSchemaType.ts
@@ -37,38 +37,29 @@ const refKeyword = new Set([
     "$ref"
 ]);
 
-export const inferSchemaType = (nodeData: GraphNode["data"]["nodeData"]): [string, string] => {
+export const inferSchemaType = (nodeData: GraphNode["data"]["nodeData"]): string => {
     const typeValue = nodeData.type?.value;
 
     if (typeof typeValue === "string") {
-        return ["objectSchema", typeValue];
+        return typeValue;
     }
 
     if (typeof typeValue === "object" && typeValue !== null && !Array.isArray(typeValue)) {
-        let primaryType = "others";
-        for (const t of Object.keys(typeValue as Record<string, string>)) {
-            if (t !== "null") {
-                primaryType = t;
-                break;
-            }
-        }
-        return ["multiType", primaryType];
+        return "multiType";
     }
 
     const hasAnyKeyword = (keywords: Set<string>) => {
         return Object.keys(nodeData).some((key) => keywords.has(key));
     }
 
-    const getBooleanSchemaValue = (value: string): string => {
-        return value ? "booleanSchemaTrue" : "booleanSchemaFalse";
+    if ("booleanSchema" in nodeData) {
+        return nodeData.booleanSchema.value ? "booleanSchemaTrue" : "booleanSchemaFalse";
     }
+    if (hasAnyKeyword(objectKeywords)) return "object";
+    if (hasAnyKeyword(arrayKeywords)) return "array";
+    if (hasAnyKeyword(stringKeywords)) return "string";
+    if (hasAnyKeyword(numberKeywords)) return "number";
+    if (hasAnyKeyword(refKeyword)) return "reference";
 
-    if ("booleanSchema" in nodeData) return ["booleanSchema", getBooleanSchemaValue(nodeData.booleanSchema.value as string)];
-    if (hasAnyKeyword(objectKeywords)) return ["objectSchema", "object"];
-    if (hasAnyKeyword(arrayKeywords)) return ["objectSchema", "array"];
-    if (hasAnyKeyword(stringKeywords)) return ["objectSchema", "string"];
-    if (hasAnyKeyword(numberKeywords)) return ["objectSchema", "number"];
-    if (hasAnyKeyword(refKeyword)) return ["objectSchema", "reference"];
-
-    return ["objectSchema", "others"];
+    return "others";
 };

--- a/src/utils/inferSchemaType.ts
+++ b/src/utils/inferSchemaType.ts
@@ -37,22 +37,22 @@ const refKeyword = new Set([
     "$ref"
 ]);
 
-export const inferSchemaType = (nodeData: GraphNode["data"]["nodeData"]): [string, string, string[]?] => {
+export const inferSchemaType = (nodeData: GraphNode["data"]["nodeData"]): [string, string] => {
     const typeValue = nodeData.type?.value;
 
     if (typeof typeValue === "string") {
         return ["objectSchema", typeValue];
     }
 
-    if (Array.isArray(typeValue)) {
+    if (typeof typeValue === "object" && typeValue !== null && !Array.isArray(typeValue)) {
         let primaryType = "others";
-        for (const t of typeValue as string[]) {
+        for (const t of Object.keys(typeValue as Record<string, string>)) {
             if (t !== "null") {
                 primaryType = t;
                 break;
             }
         }
-        return ["multiType", primaryType, typeValue as string[]];
+        return ["multiType", primaryType];
     }
 
     const hasAnyKeyword = (keywords: Set<string>) => {

--- a/src/utils/processAST.ts
+++ b/src/utils/processAST.ts
@@ -80,7 +80,7 @@ type GenerateSourceHandles = (key: string | undefined, value: unknown, nodeId: s
 type UpdateNode = (node: UnpositionedGraphNode, update: UpdateNodeOptionalParameters) => void;
 
 
-export const neonColors = {
+const neonColors = {
     string: "#FF6EFF", // neon magenta
     number: "#00FF95", // neon mint
     integer: "#00FF95", // neon mint
@@ -158,11 +158,8 @@ export const processAST: ProcessAST = ({ ast, schemaUri, nodes, edges, parentId,
     }
 
     const getColor = (nodeData: NodeData) => {
-        const [schemaType, definedFor] = inferSchemaType(nodeData);
-        if (schemaType === "multiType") return neonColors.multiType;
-        return (
-            neonColors[definedFor as keyof typeof neonColors] ?? neonColors.others
-        );
+        const colorKey = inferSchemaType(nodeData);
+        return neonColors[colorKey as keyof typeof neonColors] ?? neonColors.others;
     };
 
     const color = getColor(nodeData);

--- a/src/utils/processAST.ts
+++ b/src/utils/processAST.ts
@@ -381,7 +381,18 @@ const keywordHandlerMap: KeywordHandlerMap = {
     },
 
     // Validation
-    "https://json-schema.org/keyword/type": createBasicKeywordHandler("type"),
+    "https://json-schema.org/keyword/type": (_ast, keywordValue) => {
+        if (Array.isArray(keywordValue)) {
+            const typeColorMap = Object.fromEntries(
+                (keywordValue as string[]).map((t) => [
+                    t,
+                    neonColors[t as keyof typeof neonColors] ?? neonColors.others,
+                ])
+            );
+            return { key: "type", data: { value: typeColorMap }, leafNode: true };
+        }
+        return { key: "type", data: { value: keywordValue }, leafNode: true };
+    },
     "https://json-schema.org/keyword/enum": createBasicKeywordHandler("enum"),
     "https://json-schema.org/keyword/const": createBasicKeywordHandler("const"),
     "https://json-schema.org/keyword/maxLength": createBasicKeywordHandler("maxLength"),

--- a/src/utils/processAST.ts
+++ b/src/utils/processAST.ts
@@ -32,7 +32,7 @@ export type RFNodeData = {
 }
 
 type NodeStyle = {
-    color: string
+    color: string;
 }
 
 export type GraphEdge = RFEdge & {
@@ -80,7 +80,7 @@ type GenerateSourceHandles = (key: string | undefined, value: unknown, nodeId: s
 type UpdateNode = (node: UnpositionedGraphNode, update: UpdateNodeOptionalParameters) => void;
 
 
-const neonColors = {
+export const neonColors = {
     string: "#FF6EFF", // neon magenta
     number: "#00FF95", // neon mint
     integer: "#00FF95", // neon mint
@@ -91,6 +91,7 @@ const neonColors = {
     booleanSchemaTrue: "#12FF4B", // neon green
     booleanSchemaFalse: "#FF3B3B", // neon red 
     reference: "#FFE1BD", // soft neon cream
+    multiType: "#FF007F", // neon rose 
     others: "#CCCCCC", // soft gray
 };
 
@@ -157,7 +158,8 @@ export const processAST: ProcessAST = ({ ast, schemaUri, nodes, edges, parentId,
     }
 
     const getColor = (nodeData: NodeData) => {
-        const [, definedFor] = inferSchemaType(nodeData);
+        const [schemaType, definedFor] = inferSchemaType(nodeData);
+        if (schemaType === "multiType") return neonColors.multiType;
         return (
             neonColors[definedFor as keyof typeof neonColors] ?? neonColors.others
         );
@@ -179,7 +181,7 @@ export const processAST: ProcessAST = ({ ast, schemaUri, nodes, edges, parentId,
 
     updateNode(
         newNode,
-        { nodeData, nodeStyle: { color: color }, addTargetHandle: { handleId: targetHandle, position: Position.Left } }
+        { nodeData, nodeStyle: { color }, addTargetHandle: { handleId: targetHandle, position: Position.Left } }
     );
 };
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where multi-type schemas (e.g., `["string", "null"]` or `["integer", "number"]`) were failing type inference. Previously, the logic only accounted for primitive string types, causing multi-type nodes to fall through and render with the default "others" (gray) styling.

## What Changed

- **`src/utils/inferSchemaType.ts`**: Updated the type inference logic to properly check if the `type` property is an array. When an array of types is encountered, it selects the first non-null type as the `primaryType` (e.g., extracting `"integer"` from `["integer", "null"]`). This ensures the node receives the correct semantic coloring based on its primary data type.

##Closes #339

## Testing

Test with the following schema to verify the nodes render with their correct semantic colors and display the array values properly:

```json
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "type": "object",
  "properties": {
    "name": { "type": "string" },
    "age": { "type": ["integer", "null"] },
    "score": { "type": ["number", "string", "null"] }
  }
}
```
- `age` should render with neon mint coloring (for integer).
- `score` should render with neon mint coloring (for number).

<img width="1351" height="704" alt="image" src="https://github.com/user-attachments/assets/bf08e793-ab50-4ac6-b331-c510f9ff1594" />

<img width="1339" height="703" alt="image" src="https://github.com/user-attachments/assets/c9f36667-8b34-42fe-a767-2e0047513f07" />
