### PR TITLE
fix: replace setTimeout with requestAnimationFrame for fitView

### DIFF
--- a/.changeset/fix-graph-zoom-jerk.md
+++ b/.changeset/fix-graph-zoom-jerk.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": patch
+---
+
+fix: smooth graph zoom by replacing setTimeout with requestAnimationFrame after collision resolution

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -261,12 +261,15 @@ const GraphView = ({
     });
     setNodes(resolved);
     setCollisionResolved(true);
-    
+  }, [nodes, collisionResolved, allNodesMeasured, setNodes]);
+
+  useEffect(() => {
+    if (!collisionResolved) return;
     const rafId = requestAnimationFrame(() => {
-      fitView({ padding: 0.05 });
+      fitView({ padding: 0.05, duration: 300 });
     });
     return () => cancelAnimationFrame(rafId);
-  }, [nodes, collisionResolved, allNodesMeasured, setNodes, fitView]);
+  }, [collisionResolved, fitView]);
 
   useEffect(() => {
     if (errorMessage) {

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -261,10 +261,11 @@ const GraphView = ({
     });
     setNodes(resolved);
     setCollisionResolved(true);
-
-    setTimeout(() => {
-      fitView({ duration: 800, padding: 0.05 });
-    }, 300);
+    
+    const rafId = requestAnimationFrame(() => {
+      fitView({ padding: 0.05 });
+    });
+    return () => cancelAnimationFrame(rafId);
   }, [nodes, collisionResolved, allNodesMeasured, setNodes, fitView]);
 
   useEffect(() => {


### PR DESCRIPTION
### Description
Replaced `setTimeout` with `requestAnimationFrame` (rAF) and removed the animation duration. 
By using `requestAnimationFrame`, we sync our `fitView` call exactly with the browser's paint cycle. This guarantees that `fitView` fires instantly *after* the DOM has fully committed the resolved node positions, making the load sequence look like a single, seamless frame.

## closes #348 

### Before (the jerky situation)

<img width="1033" height="557" alt="image" src="https://github.com/user-attachments/assets/44583280-37c6-499b-b08a-a8f1e976651b" />

### After (the smooth)
<img width="1043" height="483" alt="image" src="https://github.com/user-attachments/assets/fd69c285-9c77-488c-833d-e55eb3e12602" />
