### PR TITLE
feat: add F key shortcut to toggle fullscreen

### DIFF
--- a/.changeset/fullscreen-f-shortcut.md
+++ b/.changeset/fullscreen-f-shortcut.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": minor
+---
+
+Add F key shortcut to toggle fullscreen mode

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -127,6 +127,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       if (repeat || key.toLowerCase() !== "f" || ctrlKey || metaKey || altKey || shiftKey) return;
       const el = target as HTMLElement;
       if (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT" || el.isContentEditable) return;
+      if (el.closest(".monaco-editor")) return;
       toggleFullScreen();
     };
     document.addEventListener("keydown", handleKeyDown);

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -123,6 +123,17 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   useEffect(() => {
+    const handleKeyDown = ({ key, ctrlKey, metaKey, altKey, shiftKey, repeat, target }: KeyboardEvent) => {
+      if (repeat || key.toLowerCase() !== "f" || ctrlKey || metaKey || altKey || shiftKey) return;
+      const el = target as HTMLElement;
+      if (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT" || el.isContentEditable) return;
+      toggleFullScreen();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [toggleFullScreen]);
+
+  useEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);
   }, [theme]);
 


### PR DESCRIPTION
Closes #279

Pressing `F` now toggles fullscreen, matching the standard video-player UX.

The listener ignores the key when focus is in an input, textarea (including the Monaco editor), select, or contenteditable element, so typing `f` in those never triggers it. It also ignores key-repeat (holding `F`) and any modifier combo (Ctrl/Cmd/Alt/Shift) to avoid clobbering browser shortcuts like Cmd/Ctrl+F.