### PR TITLE
fix: prevent mutation of parsedSchema in buildSchemaDocument

### DIFF
--- a/.changeset/thirty-impalas-wash.md
+++ b/.changeset/thirty-impalas-wash.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": patch
+---
+
+Prevent mutation of original parsedSchema by passing a clone to buildSchemaDocument

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -298,9 +298,14 @@ const MonacoEditor = () => {
 
     const timeout = setTimeout(async () => {
       try {
-        // INFO: parsedSchema is mutated by buildSchemaDocument function
+        // Parse the schema into a new object
         const parsedSchema = parseSchema(schemaText, schemaFormat);
-        const copy = structuredClone(parsedSchema);
+
+        // Save the pristine original before any mutations occur
+        saveSchemaJSON(SESSION_SCHEMA_KEY, parsedSchema);
+        
+        // Create a disposable clone for the mutation-heavy builder
+        const schemaForBuild = structuredClone(parsedSchema);
 
         const dialect = parsedSchema.$schema;
         const dialectVersion = dialect ?? DEFAULT_SCHEMA_DIALECT;
@@ -314,7 +319,7 @@ const MonacoEditor = () => {
         }
 
         const schemaDocument = buildSchemaDocument(
-          parsedSchema as SchemaObject,
+          schemaForBuild as SchemaObject,
           schemaId,
           dialectVersion
         );
@@ -346,7 +351,6 @@ const MonacoEditor = () => {
               }
         );
 
-        saveSchemaJSON(SESSION_SCHEMA_KEY, copy);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
 

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -298,13 +298,11 @@ const MonacoEditor = () => {
 
     const timeout = setTimeout(async () => {
       try {
-        // Parse the schema into a new object
+        // INFO: parsedSchema is mutated by buildSchemaDocument function
         const parsedSchema = parseSchema(schemaText, schemaFormat);
 
-        // Save the pristine original before any mutations occur
         saveSchemaJSON(SESSION_SCHEMA_KEY, parsedSchema);
         
-        // Create a disposable clone for the mutation-heavy builder
         const schemaForBuild = structuredClone(parsedSchema);
 
         const dialect = parsedSchema.$schema;

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -300,8 +300,6 @@ const MonacoEditor = () => {
       try {
         // INFO: parsedSchema is mutated by buildSchemaDocument function
         const parsedSchema = parseSchema(schemaText, schemaFormat);
-
-        saveSchemaJSON(SESSION_SCHEMA_KEY, parsedSchema);
         
         const schemaForBuild = structuredClone(parsedSchema);
 
@@ -349,6 +347,7 @@ const MonacoEditor = () => {
               }
         );
 
+        saveSchemaJSON(SESSION_SCHEMA_KEY, parsedSchema);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
 


### PR DESCRIPTION
## Summary

Prevent mutation of original parsedSchema by buildSchemaDocument in MonacoEditor.
The pristine original is now saved to session storage immediately after parsing,
and a disposable clone is passed to buildSchemaDocument instead.

## What kind of change does this PR introduce

Bug fix / Code quality improvement

## Issue Number

Closes #310

## Screenshots/Video

Not applicable - this is a code logic change with no UI impact.

## Does this PR introduce a breaking change?

No

## If relevant, did you update the documentation?

No - no documentation update needed for this change.
