### PR TITLE
fix: resolve node handle misalignment during live edits

### DIFF
--- a/.changeset/fix-handle-misalignment.md
+++ b/.changeset/fix-handle-misalignment.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": patch
+---
+
+fix: resolve node handle misalignment during live edits by using ResizeObserver and unscaled offsets

--- a/src/components/CustomReactFlowNode.tsx
+++ b/src/components/CustomReactFlowNode.tsx
@@ -9,37 +9,66 @@ const CustomNode = ({ data, id, selected }: { data: RFNodeData; id: string; sele
   const rowRefs = useRef<
     Record<string, HTMLDivElement | HTMLSpanElement | null>
   >({});
+  const nodeRef = useRef<HTMLDivElement>(null);
   const [handleOffsets, setHandleOffsets] = useState<Record<string, number>>(
     {}
   );
   const updateNodeInternals = useUpdateNodeInternals();
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      updateNodeInternals(id);
-    }, 0);
-    return () => clearTimeout(timer);
-  }, [handleOffsets, id, updateNodeInternals]);
+    if (!nodeRef.current) return;
 
-  useLayoutEffect(() => {
-    const container = Object.values(rowRefs.current)[0]?.offsetParent;
-    if (!(container instanceof HTMLElement)) return;
+    const updateOffsets = () => {
+      const container = nodeRef.current;
+      if (!container) return;
 
-    const containerRect = container.getBoundingClientRect();
-    const offsets: Record<string, number> = {};
+      const offsets: Record<string, number> = {};
+      let changed = false;
 
-    for (const [key, row] of Object.entries(rowRefs.current)) {
-      if (!row) continue;
+      for (const [key, row] of Object.entries(rowRefs.current)) {
+        if (!row) continue;
 
-      const rect = row.getBoundingClientRect();
-      offsets[key] = rect.top + rect.height / 2 - containerRect.top;
-    }
+        // Compute local unscaled coordinates by climbing offsetParents up to the container
+        let top = 0;
+        let el: HTMLElement | null = row;
+        while (el && el !== container) {
+          top += el.offsetTop;
+          el = el.offsetParent as HTMLElement | null;
+        }
 
-    setHandleOffsets(offsets);
-  }, [data.nodeData]);
+        offsets[key] = top + row.offsetHeight / 2;
+      }
+
+      setHandleOffsets((prev) => {
+        if (Object.keys(prev).length !== Object.keys(offsets).length) changed = true;
+        else {
+          for (const k in offsets) {
+            if (prev[k] !== offsets[k]) {
+              changed = true;
+              break;
+            }
+          }
+        }
+        if (changed) {
+          // React state update triggers re-render, we notify React Flow immediately after
+          setTimeout(() => updateNodeInternals(id), 0);
+          return offsets;
+        }
+        return prev;
+      });
+    };
+
+    // Use ResizeObserver to catch layout changes regardless of data changes or word wraps
+    const observer = new ResizeObserver(updateOffsets);
+    observer.observe(nodeRef.current);
+    updateOffsets(); // Run initially
+
+    return () => observer.disconnect();
+  }, [id, updateNodeInternals, data.nodeData]);
 
   return (
     <div
+      ref={nodeRef}
       className={`
         ${
           data.isBooleanNode

--- a/src/components/CustomReactFlowNode.tsx
+++ b/src/components/CustomReactFlowNode.tsx
@@ -1,6 +1,6 @@
-import { Handle } from "@xyflow/react";
+import { Handle, useUpdateNodeInternals } from "@xyflow/react";
 import type { RFNodeData } from "../utils/processAST";
-import { useContext, useLayoutEffect, useRef, useState } from "react";
+import { useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { AppContext } from "../contexts/AppContext";
 
 const CustomNode = ({ data, id, selected }: { data: RFNodeData; id: string; selected: boolean }) => {
@@ -12,6 +12,14 @@ const CustomNode = ({ data, id, selected }: { data: RFNodeData; id: string; sele
   const [handleOffsets, setHandleOffsets] = useState<Record<string, number>>(
     {}
   );
+  const updateNodeInternals = useUpdateNodeInternals();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      updateNodeInternals(id);
+    }, 0);
+    return () => clearTimeout(timer);
+  }, [handleOffsets, id, updateNodeInternals]);
 
   useLayoutEffect(() => {
     const container = Object.values(rowRefs.current)[0]?.offsetParent;


### PR DESCRIPTION
## Summary

This PR resolves an issue where React Flow connection lines (edges) become visually misaligned when a node's internal dimensions or row positions change dynamically during live schema editing. 

## What kind of change does this PR introduce

Bug fix

## Issue Number

Closes #338

## Screenshots/Video

before :
<img width="1527" height="742" alt="image" src="https://github.com/user-attachments/assets/796eabf1-8172-42af-a73c-7659c7a3d85b" />


after : 
<img width="1533" height="740" alt="image" src="https://github.com/user-attachments/assets/8712a285-08d4-40b9-a7f0-78098a3d312a" />



## Does this PR introduce a breaking change?

No. This is a targeted UI fix to ensure React Flow recalculates node internals correctly.

## If relevant, did you update the documentation?

No documentation updates were necessary.