### PR TITLE
fix: use instanceof for InvalidSchemaError detection in prod builds

### DIFF
--- a/.changeset/cyan-views-thank.md
+++ b/.changeset/cyan-views-thank.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": patch
+---
+
+fix: use instanceof for InvalidSchemaError detection in prod builds

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -10,7 +10,11 @@ import {
 } from "react-resizable-panels";
 // INFO: modifying the following import statement to (import type { SchemaObject } from "@hyperjump/json-schema/draft-2020-12") creates error;
 import { type SchemaObject } from "@hyperjump/json-schema/draft-2020-12";
-import { setMetaSchemaOutputFormat, unregisterSchema } from "@hyperjump/json-schema";
+import {
+  setMetaSchemaOutputFormat,
+  unregisterSchema,
+  InvalidSchemaError,
+} from "@hyperjump/json-schema";
 import {
   getSchema,
   compile,
@@ -379,8 +383,7 @@ const MonacoEditor = () => {
         } catch (compileErr) {
           // If compile fails, it could be InvalidSchemaError
           const isInvalidSchema =
-            compileErr instanceof Error &&
-            compileErr.name === "InvalidSchemaError" &&
+            compileErr instanceof InvalidSchemaError &&
             (compileErr as any).output?.errors;
 
           if (isInvalidSchema) {


### PR DESCRIPTION
Entering an invalid schema type (e.g. stringg) showed the correct "Schema Errors (1)" popup in dev, but the wrong "Syntax Error / Invalid Schema" popup in the production build. The error handler detected Hyperjump's InvalidSchemaError by comparing compileErr.name === "InvalidSchemaError", but that name comes from this.constructor.name, which gets minified in production build. So the check silently failed and the error fell through to the generic syntax-error branch.