### PR TITLE
fix: correct search bar and theme toggle placement in Firefox

### DIFF
--- a/.changeset/firefox-search-bar-fix.md
+++ b/.changeset/firefox-search-bar-fix.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": patch
+---
+
+Fix misplaced search bar and theme toggle icon in Firefox by allowing the search input to shrink within its flex container

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -108,7 +108,7 @@ const NavigationBar = () => {
               maxLength={30}
               placeholder="Search node"
               aria-label="Search nodes"
-              className="outline-none bg-transparent text-[var(--navigation-text-color)] text-sm placeholder:text-[var(--navigation-text-color)]"
+              className="outline-none bg-transparent text-[var(--navigation-text-color)] text-sm placeholder:text-[var(--navigation-text-color)] flex-1 min-w-0"
               value={searchString}
               onChange={(e) => setSearchString(e.target.value)}
               onKeyDown={handleKeyDown}

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -114,7 +114,7 @@ const NavigationBar = () => {
               onKeyDown={handleKeyDown}
             />
 
-            <div className="w-[40px] flex justify-end pr-5">
+            <div className="flex justify-end">
               {searchString ? (
                 <button
                   aria-label="Clear search"


### PR DESCRIPTION
Before:
<img width="1440" height="184" alt="Screenshot 2026-07-23 at 1 17 28 AM" src="https://github.com/user-attachments/assets/3f8061d7-1e16-4c03-8045-9b92fa8b72c0" />
After Fix:
<img width="1440" height="176" alt="Screenshot 2026-07-23 at 1 17 53 AM" src="https://github.com/user-attachments/assets/9bf4e0d6-ed23-45fe-aa6b-bed5bf66d045" />
## Summary

Fixes #373.

The search bar and dark-mode toggle icon were misplaced in Firefox (rendered correctly in Chrome).

## Root cause

The search `<input>` had no width constraint inside its fixed-width flex container (`w-[200px]`). Firefox honors the input's intrinsic minimum width (default `size=20`) and refuses to shrink it below that, so the input overflowed the container — pushing the `⌘K` badge out and shoving the theme toggle / GitHub / docs icons out of place. Chrome shrinks the input, so the layout only broke in Firefox.

## Fix

Added `flex-1 min-w-0` to the search input so it fills the available space and can shrink within the flex row, matching Chrome's rendering. CSS-only change with no behavioral impact.

## Testing

- Verified in Firefox that the search bar and toggle icons are correctly placed.
- Confirmed Chrome rendering is unchanged.