### PR TITLE
feat: add schema diff mode with graph overlay

### DIFF
--- a/.changeset/lazy-rivers-study.md
+++ b/.changeset/lazy-rivers-study.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": minor
+---
+
+Add opt-in schema diff mode with side-by-side comparison and graph overlay

--- a/src/components/CustomReactFlowNode.tsx
+++ b/src/components/CustomReactFlowNode.tsx
@@ -2,6 +2,7 @@ import { Handle, useUpdateNodeInternals } from "@xyflow/react";
 import type { RFNodeData } from "../utils/processAST";
 import { useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { AppContext } from "../contexts/AppContext";
+import { DIFF_COLORS, DIFF_LABELS } from "../utils/schemaDiff";
 
 const CustomNode = ({
   data,
@@ -38,6 +39,11 @@ const CustomNode = ({
   }, [data.nodeData]);
 
   const { color } = data.nodeStyle;
+  const diffStatus = data.diffStatus;
+  const diffColor =
+    diffStatus && diffStatus !== "unchanged"
+      ? DIFF_COLORS[diffStatus]
+      : undefined;
 
   return (
     <div
@@ -54,13 +60,19 @@ const CustomNode = ({
             ? "shadow-[0_0_15px_var(--color)] ring-2 ring-[var(--color)]"
             : ""
         }
+        ${diffStatus === "removed" ? "opacity-80" : ""}
       `}
       style={{
-        ["--color" as string]: color,
-        border:
-          theme === "dark"
+        ["--color" as string]: diffColor ?? color,
+        border: diffColor
+          ? `3px solid ${diffColor}`
+          : theme === "dark"
             ? `1px solid ${color}`
             : `1px solid color-mix(in srgb, ${color} 80%, black)`,
+        boxShadow: diffColor
+          ? `0 0 0 3px ${diffColor}55, 0 0 18px ${diffColor}88`
+          : undefined,
+        background: diffColor ? `${diffColor}18` : undefined,
         wordBreak: "break-word",
       }}
     >
@@ -74,17 +86,32 @@ const CustomNode = ({
       ))}
 
       <div
-        className="px-2 font-semibold"
+        className="px-2 font-semibold flex items-center justify-between gap-2"
         style={{
-          background: `${color}50`,
-          borderBottom: `1px solid ${color}`,
-          color:
-            theme === "dark"
+          background: diffColor ? `${diffColor}55` : `${color}50`,
+          borderBottom: `1px solid ${diffColor ?? color}`,
+          color: diffColor
+            ? theme === "dark"
+              ? "#fff"
+              : `color-mix(in srgb, ${diffColor} 45%, black)`
+            : theme === "dark"
               ? color
               : `color-mix(in srgb, ${color} 60%, black)`,
         }}
       >
-        {data.nodeLabel}
+        <span className="min-w-0 truncate">{data.nodeLabel}</span>
+        {diffColor && diffStatus && diffStatus !== "unchanged" && (
+          <span
+            className="shrink-0 text-[9px] font-bold tracking-wide px-1.5 py-0.5 rounded"
+            style={{
+              backgroundColor: diffColor,
+              color: "#111",
+            }}
+            aria-label={`Diff status: ${DIFF_LABELS[diffStatus]}`}
+          >
+            {DIFF_LABELS[diffStatus]}
+          </span>
+        )}
       </div>
 
       <div className="flex flex-col">

--- a/src/components/DiffLegend.tsx
+++ b/src/components/DiffLegend.tsx
@@ -1,0 +1,27 @@
+import { DIFF_COLORS, DIFF_LABELS, type DiffStatus } from "../utils/schemaDiff";
+
+const LEGEND_STATUSES: Exclude<DiffStatus, "unchanged">[] = ["added", "removed", "modified"];
+
+/** Small color key shown on the graph while Diff mode is active. */
+const DiffLegend = () => (
+  <div
+    className="absolute top-11 left-3 z-10 flex flex-col gap-1 px-2 py-1.5 rounded border border-[var(--popup-border-color)] bg-[var(--node-bg-color)] opacity-90 shadow-sm"
+    aria-label="Diff color legend"
+  >
+    <span className="text-[10px] font-semibold text-[var(--text-color)] tracking-wide uppercase">
+      Diff
+    </span>
+    {LEGEND_STATUSES.map((status) => (
+      <div key={status} className="flex items-center gap-1.5">
+        <span
+          className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+          style={{ backgroundColor: DIFF_COLORS[status] }}
+          aria-hidden
+        />
+        <span className="text-[10px] text-[var(--text-color)]">{DIFF_LABELS[status]}</span>
+      </div>
+    ))}
+  </div>
+);
+
+export default DiffLegend;

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -33,12 +33,19 @@ import {
   type GraphEdge,
   type GraphNode,
   type NodeData,
+  type RFNodeData,
 } from "../utils/processAST";
 import { sortAST } from "../utils/sortAST";
 import { resolveCollisions } from "../utils/resolveCollisions";
 import { MdNavigateBefore, MdNavigateNext } from "react-icons/md";
 import { CgClose } from "react-icons/cg";
 import { extractKeywords } from "../utils/searchNodeHelpers";
+import {
+  computeNodeDiffMap,
+  mergeDiffGraphs,
+  type DiffStatus,
+} from "../utils/schemaDiff";
+import DiffLegend from "./DiffLegend";
 
 const nodeTypes = { customNode: CustomNode };
 
@@ -46,11 +53,19 @@ const NODE_WIDTH = 172;
 const NODE_HEIGHT = 36;
 const HORIZONTAL_GAP = 150;
 
+type GraphViewProps = {
+  compiledSchema: CompiledSchema | null;
+  diffCompiledSchema?: CompiledSchema | null;
+  isDiffMode?: boolean;
+  onDiffNodeSelect?: (identity: string, status: DiffStatus) => void;
+};
+
 const GraphView = ({
   compiledSchema,
-}: {
-  compiledSchema: CompiledSchema | null;
-}) => {
+  diffCompiledSchema = null,
+  isDiffMode = false,
+  onDiffNodeSelect,
+}: GraphViewProps) => {
   const { setCenter, getZoom, fitView, getNodes } = useReactFlow();
   const { theme, selectedNode, setSelectedNode, searchString, registerNavigateMatch, registerExportGraph } =
     useContext(AppContext);
@@ -115,6 +130,12 @@ const GraphView = ({
       });
       setOpenNodeDetailsPopup(false);
     }
+
+    const status = (node.data as RFNodeData).diffStatus;
+    if (isDiffMode && status && status !== "unchanged" && onDiffNodeSelect) {
+      onDiffNodeSelect(node.id, status);
+    }
+
     // Select connected edges programmatically to allow native selection handling
     setEdges((eds) =>
       eds.map((edge) => {
@@ -125,7 +146,7 @@ const GraphView = ({
         };
       })
     );
-  }, [selectedNode, setSelectedNode, setEdges]);
+  }, [selectedNode, setSelectedNode, setEdges, isDiffMode, onDiffNodeSelect]);
 
   const generateNodesAndEdges = useCallback(
     (
@@ -235,7 +256,25 @@ const GraphView = ({
       const result = generateNodesAndEdges(compiledSchema);
       if (!result) return;
 
-      const { nodes: rawNodes, edges: rawEdges } = result;
+      let rawNodes = result.nodes;
+      let rawEdges = result.edges;
+
+      if (isDiffMode && diffCompiledSchema) {
+        const compare = generateNodesAndEdges(diffCompiledSchema);
+        if (compare) {
+          const diffMap = computeNodeDiffMap(result.nodes, compare.nodes);
+          const merged = mergeDiffGraphs(
+            result.nodes,
+            result.edges,
+            compare.nodes,
+            compare.edges,
+            diffMap
+          );
+          rawNodes = merged.nodes;
+          rawEdges = merged.edges;
+        }
+      }
+
       const { nodes: layoutedNodes, edges: layoutedEdges } =
         getLayoutedElements(rawNodes, rawEdges);
 
@@ -249,6 +288,8 @@ const GraphView = ({
     }
   }, [
     compiledSchema,
+    diffCompiledSchema,
+    isDiffMode,
     generateNodesAndEdges,
     getLayoutedElements,
     setEdges,
@@ -463,6 +504,8 @@ const GraphView = ({
         />
         <Controls />
       </ReactFlow>
+
+      {isDiffMode && <DiffLegend />}
 
       {openNodeDetailsPopup && selectedNode && (
         <NodeDetailsPopup

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -273,33 +273,45 @@ const MonacoEditor = () => {
     }, 300);
   };
 
-  const toggleDiffMode = () => {
-    setIsDiffMode((prev) => {
-      const next = !prev;
-      if (next) {
-        setCompareSchemaText(schemaText);
-        if (editorVisible && !isMobile) {
-          setDiffEditorReady(false);
-          editorPanelRef.current?.resize(DIFF_EDITOR_PANEL_WIDTH);
-          window.setTimeout(() => {
-            setDiffEditorReady(true);
-          }, 320);
-        } else {
-          setDiffEditorReady(true);
-        }
-      } else {
-        setDiffEditorReady(false);
-        setDiffCompiledSchema(null);
-        diffEditorRef.current = null;
-        diffResizeObserverRef.current?.disconnect();
-        diffResizeObserverRef.current = null;
-        if (editorVisible && !isMobile) {
-          editorPanelRef.current?.resize(DEFAULT_EDITOR_PANEL_WIDTH);
-        }
-      }
-      return next;
-    });
-  };
+const toggleDiffMode = () => {
+  if (isDiffMode) {
+    // Turning Diff mode OFF.
+    // Dispose Monaco's diff editor + its models BEFORE React unmounts
+    // the <DiffEditor> component — this is the actual race condition fix.
+    const diffEditor = diffEditorRef.current;
+    if (diffEditor) {
+      const model = diffEditor.getModel(); // { original, modified }
+      diffEditor.setModel(null);           // detach models first
+      model?.original?.dispose();
+      model?.modified?.dispose();
+      diffEditor.dispose();                // now dispose the widget itself
+    }
+    diffEditorRef.current = null;
+
+    diffResizeObserverRef.current?.disconnect();
+    diffResizeObserverRef.current = null;
+
+    setDiffEditorReady(false);
+    setDiffCompiledSchema(null);
+    if (editorVisible && !isMobile) {
+      editorPanelRef.current?.resize(DEFAULT_EDITOR_PANEL_WIDTH);
+    }
+    setIsDiffMode(false);
+  } else {
+    // Turning Diff mode ON.
+    setCompareSchemaText(schemaText);
+    if (editorVisible && !isMobile) {
+      setDiffEditorReady(false);
+      editorPanelRef.current?.resize(DIFF_EDITOR_PANEL_WIDTH);
+      window.setTimeout(() => {
+        setDiffEditorReady(true);
+      }, 320);
+    } else {
+      setDiffEditorReady(true);
+    }
+    setIsDiffMode(true);
+  }
+};
 
   const highlightInStandaloneEditor = (
     target: editor.IStandaloneCodeEditor,

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -1,6 +1,7 @@
 import { useContext, useState, useEffect, useRef, useMemo } from "react";
 import { BsUpload, BsDownload } from "react-icons/bs";
 import { SESSION_SCHEMA_KEY } from "../constants";
+import YAML from "js-yaml";
 
 import {
   Panel,
@@ -24,7 +25,7 @@ import {
 } from "@hyperjump/json-schema/experimental";
 import { jsonSchemaErrors } from "@hyperjump/json-schema-errors";
 
-import Editor, { type OnMount } from "@monaco-editor/react";
+import Editor, { DiffEditor, type OnMount, type DiffOnMount } from "@monaco-editor/react";
 import type { editor } from "monaco-editor";
 import { AppContext, type SchemaFormat } from "../contexts/AppContext";
 import SchemaVisualization from "./SchemaVisualization";
@@ -38,6 +39,11 @@ import {
 import { pointerSegments } from "@hyperjump/json-pointer";
 import { getKeywordDocLink } from "../utils/keywordDocs";
 import SchemaErrorsPopup from "./SchemaErrorsPopup";
+import { compileSchemaForGraph } from "../utils/compileSchemaForGraph";
+import {
+  identityToPath,
+  type DiffStatus,
+} from "../utils/schemaDiff";
 
 export type ValidationStatus = {
   status: "success" | "warning" | "error";
@@ -63,6 +69,8 @@ type CreateBrowser = (
 const DEFAULT_SCHEMA_ID = "https://studio.ioflux.org/schema";
 const DEFAULT_SCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema";
 const DEFAULT_EDITOR_PANEL_WIDTH = 25; // in percentage
+const DIFF_EDITOR_PANEL_WIDTH = 45; 
+
 
 const JSON_SCHEMA_DIALECTS = [
   "https://json-schema.org/draft/2020-12/schema",
@@ -113,6 +121,9 @@ const MonacoEditor = () => {
   } = useContext(AppContext);
 
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+  const diffEditorRef = useRef<editor.IStandaloneDiffEditor | null>(null);
+  const diffContainerRef = useRef<HTMLDivElement | null>(null);
+  const diffResizeObserverRef = useRef<ResizeObserver | null>(null);
   const editorPanelRef = useRef<ImperativePanelHandle>(null);
 
   const handleEditorDidMount: OnMount = (editor) => {
@@ -122,6 +133,13 @@ const MonacoEditor = () => {
   const [compiledSchema, setCompiledSchema] = useState<CompiledSchema | null>(
     null
   );
+  const [diffCompiledSchema, setDiffCompiledSchema] =
+    useState<CompiledSchema | null>(null);
+
+  const [isDiffMode, setIsDiffMode] = useState(false);
+  const [compareSchemaText, setCompareSchemaText] = useState("");
+  const [diffEditorReady, setDiffEditorReady] = useState(false);
+  const [compareError, setCompareError] = useState<string | null>(null);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -239,7 +257,13 @@ const MonacoEditor = () => {
     if (editorVisible) {
       editorPanelRef.current.collapse();
     } else {
-      editorPanelRef.current.resize(isMobile ? 40 : DEFAULT_EDITOR_PANEL_WIDTH);
+      editorPanelRef.current.resize(
+        isMobile
+          ? 40
+          : isDiffMode
+            ? DIFF_EDITOR_PANEL_WIDTH
+            : DEFAULT_EDITOR_PANEL_WIDTH
+      );
     }
 
     setEditorVisible((prev) => !prev);
@@ -249,20 +273,50 @@ const MonacoEditor = () => {
     }, 300);
   };
 
-  const highlightPathInEditor = (path: (string | number)[]) => {
-    if (!editorRef.current) return;
-    const model = editorRef.current.getModel();
+  const toggleDiffMode = () => {
+    setIsDiffMode((prev) => {
+      const next = !prev;
+      if (next) {
+        setCompareSchemaText(schemaText);
+        if (editorVisible && !isMobile) {
+          setDiffEditorReady(false);
+          editorPanelRef.current?.resize(DIFF_EDITOR_PANEL_WIDTH);
+          window.setTimeout(() => {
+            setDiffEditorReady(true);
+          }, 320);
+        } else {
+          setDiffEditorReady(true);
+        }
+      } else {
+        setDiffEditorReady(false);
+        setDiffCompiledSchema(null);
+        diffEditorRef.current = null;
+        diffResizeObserverRef.current?.disconnect();
+        diffResizeObserverRef.current = null;
+        if (editorVisible && !isMobile) {
+          editorPanelRef.current?.resize(DEFAULT_EDITOR_PANEL_WIDTH);
+        }
+      }
+      return next;
+    });
+  };
+
+  const highlightInStandaloneEditor = (
+    target: editor.IStandaloneCodeEditor,
+    text: string,
+    path: (string | number)[]
+  ) => {
+    const model = target.getModel();
     if (!model) return;
 
-    const text = model.getValue();
     const range = getHighlightedNodeRangeFromPath(text, path, schemaFormat);
     if (!range) return;
 
     const startPos = model.getPositionAt(range.start);
     const endPos = model.getPositionAt(range.end);
 
-    editorRef.current.revealPositionInCenter(startPos);
-    editorRef.current.setPosition(startPos);
+    target.revealPositionInCenter(startPos);
+    target.setPosition(startPos);
 
     const decoration = {
       range: new (window as any).monaco.Range(
@@ -282,19 +336,105 @@ const MonacoEditor = () => {
     model.deltaDecorations(oldDecorations, [decoration]);
   };
 
-  useEffect(() => {
+  const highlightPathInEditor = (path: (string | number)[]) => {
+    if (isDiffMode && diffEditorRef.current) {
+      const modified = diffEditorRef.current.getModifiedEditor();
+      const modifiedText = modified.getModel()?.getValue() ?? compareSchemaText;
+      highlightInStandaloneEditor(modified, modifiedText, path);
+      return;
+    }
     if (!editorRef.current) return;
-    const model = editorRef.current.getModel();
-    if (!model) return;
+    const currentText = editorRef.current.getModel()?.getValue() ?? schemaText;
+    highlightInStandaloneEditor(editorRef.current, currentText, path);
+  };
 
-    if (!selectedNode?.id) {
+  const handleDiffNodeSelect = (identity: string, status: DiffStatus) => {
+    if (!diffEditorRef.current) return;
+    const path = identityToPath(identity);
+    const useOriginal = status === "removed";
+    const target = useOriginal
+      ? diffEditorRef.current.getOriginalEditor()
+      : diffEditorRef.current.getModifiedEditor();
+    const text = useOriginal ? schemaText : compareSchemaText;
+    highlightInStandaloneEditor(target, text, path);
+  };
+
+  const layoutDiffEditor = () => {
+    const diffEditor = diffEditorRef.current;
+    const container = diffContainerRef.current;
+    if (!diffEditor || !container) return;
+    diffEditor.layout({
+      width: container.clientWidth,
+      height: container.clientHeight,
+    });
+  };
+
+  const handleDiffEditorMount: DiffOnMount = (diffEditor) => {
+    diffEditorRef.current = diffEditor;
+
+    const modified = diffEditor.getModifiedEditor();
+
+    modified.onDidChangeModelContent(() => {
+      setCompareSchemaText(modified.getValue());
+    });
+
+    diffResizeObserverRef.current?.disconnect();
+    const container = diffContainerRef.current;
+    if (container) {
+      const observer = new ResizeObserver(() => {
+        layoutDiffEditor();
+      });
+      observer.observe(container);
+      diffResizeObserverRef.current = observer;
+    }
+
+    requestAnimationFrame(() => {
+      layoutDiffEditor();
+    });
+  };
+
+  const handleSchemaFormatChange = (format: SchemaFormat) => {
+    if (isDiffMode && format !== schemaFormat) {
+      try {
+        if (format === "yaml") {
+          const parsed = JSON.parse(compareSchemaText);
+          setCompareSchemaText(YAML.dump(parsed));
+        } else {
+          const parsed = YAML.load(compareSchemaText) as object;
+          setCompareSchemaText(JSON.stringify(parsed, null, 2));
+        }
+      } catch {
+        // Keep existing compare text if conversion fails
+        return;
+      }
+    }
+    changeSchemaFormat(format);
+  };
+
+  useEffect(() => {
+    const clearHighlights = (target: editor.IStandaloneCodeEditor | null) => {
+      const model = target?.getModel();
+      if (!model) return;
       const oldDecorations = model
         .getAllDecorations()
         .filter((d: any) => d.options.className === "monaco-highlight-line")
         .map((d: any) => d.id);
       model.deltaDecorations(oldDecorations, []);
+    };
+
+    if (!selectedNode?.id) {
+      if (isDiffMode && diffEditorRef.current) {
+        clearHighlights(diffEditorRef.current.getOriginalEditor());
+        clearHighlights(diffEditorRef.current.getModifiedEditor());
+      } else {
+        clearHighlights(editorRef.current);
+      }
       return;
     }
+
+    if (isDiffMode) return;
+
+    if (!editorRef.current) return;
 
     const uriParts = selectedNode.id.split("#");
     const fragment = uriParts.length > 1 ? uriParts[1] : "";
@@ -308,9 +448,32 @@ const MonacoEditor = () => {
       });
 
     highlightPathInEditor(path);
-  }, [selectedNode?.id, schemaFormat, schemaText]);
+  }, [selectedNode?.id, schemaFormat, schemaText, isDiffMode]);
 
   const instanceId = useMemo(() => Math.random().toString(36).slice(2), []);
+  const diffInstanceId = useMemo(
+    () => `diff-${Math.random().toString(36).slice(2)}`,
+    []
+  );
+
+  useEffect(() => {
+  if (!isDiffMode) {
+    setDiffCompiledSchema(null);
+    setCompareError(null);
+    return;
+  }
+  let cancelled = false;
+  const timeout = setTimeout(async () => {
+    const { compiled, error } = await compileSchemaForGraph(compareSchemaText, schemaFormat, diffInstanceId);
+    if (cancelled) return;
+    setDiffCompiledSchema(compiled);
+    setCompareError(error);
+  }, 300);
+  return () => {
+    cancelled = true;
+    clearTimeout(timeout);
+  };
+}, [isDiffMode, compareSchemaText, schemaFormat, diffInstanceId]);
 
   useEffect(() => {
     if (!schemaText.trim()) return;
@@ -489,6 +652,24 @@ const MonacoEditor = () => {
           />
           <div className="ml-auto flex items-center gap-3">
             <button
+              type="button"
+              onClick={toggleDiffMode}
+              className={`h-[26px] flex items-center gap-1.5 border text-sm px-1.5 rounded-sm transition-opacity cursor-pointer ${
+                isDiffMode
+                  ? "bg-blue-600 text-white border-blue-600 opacity-100"
+                  : "bg-[var(--bg-color)] border-[var(--popup-border-color)] text-[var(--text-color)] hover:opacity-75"
+              }`}
+              aria-label={isDiffMode ? "Exit Diff mode" : "Enter Diff mode"}
+              aria-pressed={isDiffMode}
+              title={
+                isDiffMode
+                  ? "Exit Diff mode"
+                  : "Compare two schemas (Diff mode)"
+              }
+            >
+              <span>Diff</span>
+            </button>
+            <button
               onClick={() => fileInputRef.current?.click()}
               className="h-[26px] flex items-center gap-1.5 bg-[var(--bg-color)] border border-[var(--popup-border-color)] text-[var(--text-color)] text-sm px-1.5 rounded-sm hover:opacity-75 transition-opacity cursor-pointer"
               aria-label="Upload JSON/YAML schema file"
@@ -512,7 +693,9 @@ const MonacoEditor = () => {
             <select
               id="schema-format-select"
               value={schemaFormat}
-              onChange={(e) => changeSchemaFormat(e.target.value as SchemaFormat)}
+              onChange={(e) =>
+                handleSchemaFormatChange(e.target.value as SchemaFormat)
+              }
               className="h-[26px] min-w-[60px] px-1 flex-shrink-0 bg-[var(--bg-color)] text-[var(--text-color)] text-sm outline-none cursor-pointer border border-[var(--popup-border-color)] rounded-sm"
             >
               <option value="json">JSON</option>
@@ -532,30 +715,79 @@ const MonacoEditor = () => {
           </span>
         </div>
       </div>
-      <div className="flex-1 min-h-0">
-        <Editor
-          height="100%"
-          width="100%"
-          language={schemaFormat}
-          value={schemaText}
-          theme={theme === "light" ? "vs-light" : "vs-dark"}
-          options={{
-            minimap: { enabled: false },
-            occurrencesHighlight: "off",
-          }}
-          onChange={(value) => setSchemaText(value ?? "")}
-          onMount={handleEditorDidMount}
-        />
+      <div className="flex-1 min-h-0 flex flex-col">
+        {isDiffMode ? (
+          <>
+            <div className="flex text-[10px] uppercase tracking-wide ...">
+              <span className="flex-1 px-2 py-0.5">Current (read-only)</span>
+              <span className="flex-1 px-2 py-0.5 flex items-center gap-1">
+                Compare
+                {compareError && (
+                  <span className="text-red-500 normal-case font-normal truncate" title={compareError}>
+                    — {compareError}
+                  </span>
+                )}
+              </span>
+            </div>
+            <div ref={diffContainerRef} className="flex-1 min-h-0 relative">
+              {diffEditorReady ? (
+                <DiffEditor
+                  height="100%"
+                  width="100%"
+                  language={schemaFormat}
+                  original={schemaText}
+                  modified={compareSchemaText}
+                  theme={theme === "light" ? "vs-light" : "vs-dark"}
+                  options={{
+                    minimap: { enabled: false },
+                    renderSideBySide: true,
+                    // Monaco defaults this to 900px — below that it collapses to inline
+                    // (original pane ~38px). Keep true side-by-side in our panel.
+                    renderSideBySideInlineBreakpoint: 0,
+                    // Git-style: left (Current) locked; right (Compare) editable
+                    originalEditable: false,
+                    readOnly: false,
+                    automaticLayout: true,
+                  }}
+                  onMount={handleDiffEditorMount}
+                />
+              ) : (
+                <div className="absolute inset-0 flex items-center justify-center text-sm text-[var(--validation-heading-color)]">
+                  Preparing diff…
+                </div>
+              )}
+            </div>
+          </>
+        ) : (
+          <Editor
+            height="100%"
+            width="100%"
+            language={schemaFormat}
+            value={schemaText}
+            theme={theme === "light" ? "vs-light" : "vs-dark"}
+            options={{
+              minimap: { enabled: false },
+              occurrencesHighlight: "off",
+            }}
+            onChange={(value) => setSchemaText(value ?? "")}
+            onMount={handleEditorDidMount}
+          />
+        )}
       </div>
     </Panel>
   );
 
   const visualizationPanel = (
     <Panel
-      minSize={isMobile ? undefined : 60}
+      minSize={isMobile ? undefined : isDiffMode ? 40 : 60}
       className="flex flex-col relative bg-[var(--visualize-bg-color)]"
     >
-      <SchemaVisualization compiledSchema={compiledSchema} />
+      <SchemaVisualization
+        compiledSchema={compiledSchema}
+        diffCompiledSchema={diffCompiledSchema}
+        isDiffMode={isDiffMode}
+        onDiffNodeSelect={handleDiffNodeSelect}
+      />
       <SchemaErrorsPopup
         schemaValidation={schemaValidation}
         activeErrorIndex={activeErrorIndex}

--- a/src/components/SchemaVisualization.tsx
+++ b/src/components/SchemaVisualization.tsx
@@ -2,16 +2,32 @@ import GraphView from "./GraphView";
 import { type CompiledSchema } from "@hyperjump/json-schema/experimental";
 import { ReactFlowProvider } from "@xyflow/react";
 import { Tooltip } from "react-tooltip";
+import type { DiffStatus } from "../utils/schemaDiff";
+
+type SchemaVisualizationProps = {
+  compiledSchema: CompiledSchema | null;
+  /** When set, graph shows both schemas with diff coloring */
+  diffCompiledSchema?: CompiledSchema | null;
+  isDiffMode?: boolean;
+  /** Scroll the DiffEditor to the node path when a highlighted node is clicked */
+  onDiffNodeSelect?: (identity: string, status: DiffStatus) => void;
+};
 
 const SchemaVisualization = ({
   compiledSchema,
-}: {
-  compiledSchema: CompiledSchema | null;
-}) => {
+  diffCompiledSchema = null,
+  isDiffMode = false,
+  onDiffNodeSelect,
+}: SchemaVisualizationProps) => {
   return (
     <>
       <ReactFlowProvider>
-        <GraphView compiledSchema={compiledSchema} />
+        <GraphView
+          compiledSchema={compiledSchema}
+          diffCompiledSchema={diffCompiledSchema}
+          isDiffMode={isDiffMode}
+          onDiffNodeSelect={onDiffNodeSelect}
+        />
       </ReactFlowProvider>
       <div className="absolute bottom-[10px] right-[10px] z-10">
         <img

--- a/src/utils/compileSchemaForGraph.ts
+++ b/src/utils/compileSchemaForGraph.ts
@@ -1,0 +1,85 @@
+import { type SchemaObject } from "@hyperjump/json-schema/draft-2020-12";
+import {
+  setMetaSchemaOutputFormat,
+  unregisterSchema,
+} from "@hyperjump/json-schema";
+import {
+  getSchema,
+  compile,
+  buildSchemaDocument,
+  type CompiledSchema,
+  type SchemaDocument,
+} from "@hyperjump/json-schema/experimental";
+import { parseSchema } from "./parseSchema";
+import type { SchemaFormat } from "../contexts/AppContext";
+
+const DEFAULT_SCHEMA_ID = "https://studio.ioflux.org/schema";
+const DEFAULT_SCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema";
+
+const JSON_SCHEMA_DIALECTS = [
+  "https://json-schema.org/draft/2020-12/schema",
+  "https://json-schema.org/draft/2019-09/schema",
+  "http://json-schema.org/draft-07/schema#",
+  "http://json-schema.org/draft-06/schema#",
+  "http://json-schema.org/draft-04/schema#",
+];
+const SUPPORTED_DIALECTS = ["https://json-schema.org/draft/2020-12/schema"];
+
+type CreateBrowser = (
+  id: string,
+  schemaDoc: SchemaDocument
+) => {
+  _cache: Record<string, SchemaDocument>;
+};
+
+/**
+ * Compile schema text into a Hyperjump CompiledSchema for graph generation.
+ * Always uses a unique $id so Diff mode never races with the main editor compile.
+ */
+
+export type CompileResult = {
+  compiled: CompiledSchema | null;
+  error: string | null;
+};
+
+export const compileSchemaForGraph = async (
+  schemaText: string,
+  schemaFormat: SchemaFormat,
+  instanceSuffix: string
+): Promise<CompileResult> => {
+  if (!schemaText.trim()) return { compiled: null, error: null };
+
+  try {
+    const parsedSchema = parseSchema(schemaText, schemaFormat);
+    const schemaForBuild = structuredClone(parsedSchema);
+
+    const dialect = typeof parsedSchema !== "boolean" ? parsedSchema.$schema : undefined;
+    const dialectVersion = dialect ?? DEFAULT_SCHEMA_DIALECT;
+
+    const baseId = (typeof parsedSchema !== "boolean" && parsedSchema.$id) || DEFAULT_SCHEMA_ID;
+    const schemaId = `${baseId}__compare__${instanceSuffix}`;
+
+    if (typeof schemaForBuild !== "boolean") {
+      (schemaForBuild as SchemaObject).$id = schemaId;
+    }
+
+    if (JSON_SCHEMA_DIALECTS.includes(dialectVersion) && !SUPPORTED_DIALECTS.includes(dialectVersion)) {
+      return { compiled: null, error: `Dialect "${dialectVersion}" is not supported yet.` };
+    }
+
+    const schemaDocument = buildSchemaDocument(schemaForBuild as SchemaObject, schemaId, dialectVersion);
+    const createBrowser: CreateBrowser = (id, schemaDoc) => ({ _cache: { [id]: schemaDoc } });
+    const browser = createBrowser(schemaId, schemaDocument);
+    // @ts-expect-error — local-only cache browser is sufficient for getSchema
+    const schema = await getSchema(schemaDocument.baseUri, browser);
+
+    unregisterSchema(schemaId);
+    setMetaSchemaOutputFormat("BASIC");
+
+    const compiled = await compile(schema);
+    return { compiled, error: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { compiled: null, error: message };
+  }
+};

--- a/src/utils/processAST.ts
+++ b/src/utils/processAST.ts
@@ -28,7 +28,9 @@ export type RFNodeData = {
     nodeData: NodeData,
     nodeStyle: Partial<NodeStyle>,
     sourceHandles: HandleConfig[],
-    targetHandles: HandleConfig[]
+    targetHandles: HandleConfig[],
+
+    diffStatus?: "added" | "removed" | "modified" | "unchanged",
 }
 
 type NodeStyle = {

--- a/src/utils/schemaDiff.ts
+++ b/src/utils/schemaDiff.ts
@@ -1,0 +1,235 @@
+import type { GraphEdge, GraphNode, NodeData, RFNodeData } from "./processAST";
+
+/**
+ * Diff status for a graph node when comparing two schemas.
+ * Matching is done by URI fragment so different $id bases still align.
+ */
+export type DiffStatus = "added" | "removed" | "modified" | "unchanged";
+
+export const DIFF_COLORS: Record<Exclude<DiffStatus, "unchanged">, string> = {
+  added: "#22c55e",
+  removed: "#ef4444",
+  modified: "#eab308",
+};
+
+export const DIFF_LABELS: Record<Exclude<DiffStatus, "unchanged">, string> = {
+  added: "ADDED",
+  removed: "REMOVED",
+  modified: "MODIFIED",
+};
+
+/**
+ * Stable identity for a processAST node across two compiled schemas.
+ * Examples:
+ *   "https://example.com/schema#/properties/name" → "#/properties/name"
+ *   "https://example.com/schema"                  → "#"
+ *   "https://json-schema.org/keyword/$defs"       → (full URI, synthetic)
+ */
+export const getNodeIdentity = (nodeId: string): string => {
+  const hashIndex = nodeId.indexOf("#");
+  if (hashIndex !== -1) {
+    const fragment = nodeId.slice(hashIndex);
+    return fragment === "" ? "#" : fragment;
+  }
+
+  // Synthetic keyword container nodes (e.g. $defs wrapper) have no fragment
+  if (nodeId.includes("json-schema.org/keyword")) {
+    return nodeId;
+  }
+
+  return "#";
+};
+
+/** Content fingerprint used to detect structural modifications. */
+const nodeFingerprint = (data: RFNodeData): string =>
+  JSON.stringify({
+    label: data.nodeLabel,
+    isBoolean: data.isBooleanNode,
+    nodeData: normalizeNodeData(data.nodeData),
+  });
+
+/**
+ * Keywords that only list / point at child schema nodes.
+ * When a child is added/removed, these parent lists change too — but the real
+ * change already shows up on the child node itself. Ignoring them here prevents
+ * ancestors (e.g. root) from being falsely marked MODIFIED.
+ */
+const CHILD_STRUCTURE_KEYS = new Set([
+  "properties",
+  "$defs",
+  "definitions",
+  "allOf",
+  "anyOf",
+  "oneOf",
+  "prefixItems",
+  "patternProperties",
+  "dependentSchemas",
+  // Nested schema pointers (shown as "{ ... }" on the parent)
+  "$ref",
+  "if",
+  "then",
+  "else",
+  "not",
+  "items",
+  "contains",
+  "additionalProperties",
+  "propertyNames",
+  "unevaluatedProperties",
+  "unevaluatedItems",
+]);
+
+const normalizeNodeData = (nodeData: NodeData): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(nodeData)) {
+    // Skip child-structure keys — child add/remove is tracked via node identity
+    if (CHILD_STRUCTURE_KEYS.has(key)) continue;
+
+    // Prefer ellipsis markers (structural placeholders over absolute URIs)
+    if (entry.ellipsis) {
+      result[key] = entry.ellipsis;
+    } else {
+      result[key] = normalizeValue(entry.value);
+    }
+  }
+  return result;
+};
+
+/** Strip schema base URIs so fingerprints stay stable across different $id values */
+const normalizeValue = (value: unknown): unknown => {
+  if (typeof value === "string" && value.includes("#")) {
+    return getNodeIdentity(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(normalizeValue);
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = normalizeValue(v);
+    }
+    return out;
+  }
+  return value;
+};
+
+/**
+ * Compare two node lists by URI fragment and return a status map keyed by identity.
+ */
+export const computeNodeDiffMap = (
+  originalNodes: GraphNode[],
+  modifiedNodes: GraphNode[]
+): Map<string, DiffStatus> => {
+  const originalById = new Map<string, GraphNode>();
+  const modifiedById = new Map<string, GraphNode>();
+
+  for (const node of originalNodes) {
+    originalById.set(getNodeIdentity(node.id), node);
+  }
+  for (const node of modifiedNodes) {
+    modifiedById.set(getNodeIdentity(node.id), node);
+  }
+
+  const statuses = new Map<string, DiffStatus>();
+  const allIds = new Set([...originalById.keys(), ...modifiedById.keys()]);
+
+  for (const id of allIds) {
+    const original = originalById.get(id);
+    const modified = modifiedById.get(id);
+
+    if (original && !modified) {
+      statuses.set(id, "removed");
+    } else if (!original && modified) {
+      statuses.set(id, "added");
+    } else if (original && modified) {
+      const same =
+        nodeFingerprint(original.data) === nodeFingerprint(modified.data);
+      statuses.set(id, same ? "unchanged" : "modified");
+    }
+  }
+
+  return statuses;
+};
+
+/**
+ * Build a single graph that shows both schemas:
+ * - added / modified / unchanged → from the modified (new) schema
+ * - removed → from the original schema
+ *
+ * Node IDs are remapped to identity fragments so edges stay consistent.
+ */
+export const mergeDiffGraphs = (
+  originalNodes: GraphNode[],
+  originalEdges: GraphEdge[],
+  modifiedNodes: GraphNode[],
+  modifiedEdges: GraphEdge[],
+  diffMap: Map<string, DiffStatus>
+): { nodes: GraphNode[]; edges: GraphEdge[] } => {
+  const nodes: GraphNode[] = [];
+  const seen = new Set<string>();
+
+  const attachStatus = (node: GraphNode, status: DiffStatus): GraphNode => {
+    const identity = getNodeIdentity(node.id);
+    return {
+      ...node,
+      id: identity,
+      data: {
+        ...node.data,
+        diffStatus: status,
+      },
+    };
+  };
+
+  // Prefer modified nodes for everything except removals
+  for (const node of modifiedNodes) {
+    const identity = getNodeIdentity(node.id);
+    const status = diffMap.get(identity) ?? "unchanged";
+    nodes.push(attachStatus(node, status));
+    seen.add(identity);
+  }
+
+  // Append removed nodes from the original schema
+  for (const node of originalNodes) {
+    const identity = getNodeIdentity(node.id);
+    if (diffMap.get(identity) !== "removed") continue;
+    nodes.push(attachStatus(node, "removed"));
+    seen.add(identity);
+  }
+
+  const remapEdge = (edge: GraphEdge): GraphEdge => ({
+    ...edge,
+    id: `${getNodeIdentity(edge.source)}--${edge.sourceHandle ?? ""}--${getNodeIdentity(edge.target)}--${edge.targetHandle ?? ""}`,
+    source: getNodeIdentity(edge.source),
+    target: getNodeIdentity(edge.target),
+  });
+
+  const edgeKeys = new Set<string>();
+  const edges: GraphEdge[] = [];
+
+  const pushUnique = (edge: GraphEdge) => {
+    const remapped = remapEdge(edge);
+    if (edgeKeys.has(remapped.id)) return;
+    // Drop edges whose endpoints are missing from the merged node set
+    if (!seen.has(remapped.source) || !seen.has(remapped.target)) return;
+    edgeKeys.add(remapped.id);
+    edges.push(remapped);
+  };
+
+  for (const edge of modifiedEdges) pushUnique(edge);
+  for (const edge of originalEdges) pushUnique(edge);
+
+  return { nodes, edges };
+};
+
+/** Convert a node identity fragment into a JSON Pointer path for editor highlighting. */
+export const identityToPath = (identity: string): (string | number)[] => {
+  if (!identity || identity === "#") return [];
+
+  const fragment = identity.startsWith("#") ? identity.slice(1) : identity;
+  return fragment
+    .split("/")
+    .filter((segment) => segment !== "")
+    .map((segment) => {
+      const decoded = decodeURIComponent(segment);
+      return /^\d+$/.test(decoded) ? parseInt(decoded, 10) : decoded;
+    });
+};


### PR DESCRIPTION
## Summary
Adds an opt-in "Diff" mode that lets users compare two JSON Schema versions side by side. Toggling Diff mode switches the editor into Monaco's native diff editor (current schema on the left, read-only; a comparison schema on the right, editable). The graph view updates to show both schemas simultaneously, with nodes color-coded by diff status — green (added), red (removed), yellow (modified), default (unchanged) — and a legend explaining the colors. Clicking a highlighted node in the graph scrolls the diff editor to the corresponding change.

Default (non-diff) editor and visualization behavior is unchanged; Diff mode only activates when the user explicitly clicks the toggle.

## What kind of change does this PR introduce
New feature (opt-in), plus two small bug fixes found along the way.

## Issue Number
Closes #297

## Screenshots/Video

https://github.com/user-attachments/assets/443fa906-698e-4428-95d7-fe419fd4c0f5



## Does this PR introduce a breaking change?
No. Diff mode is fully opt-in and does not change default editor or visualization behavior.

## If relevant, did you update the documentation?
No documentation updates were needed for this change.
