### PR TITLE
fix: prevent schema corruption when switching format during a syntax …

### DIFF
--- a/.changeset/floppy-dogs-raise.md
+++ b/.changeset/floppy-dogs-raise.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": patch
+---
+
+Fix format switch corruption and disable dropdown on invalid schema

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -520,7 +520,17 @@ const MonacoEditor = () => {
               id="schema-format-select"
               value={schemaFormat}
               onChange={(e) => changeSchemaFormat(e.target.value as SchemaFormat)}
-              className="h-[26px] min-w-[60px] px-1 flex-shrink-0 bg-[var(--bg-color)] text-[var(--text-color)] text-sm outline-none cursor-pointer border border-[var(--popup-border-color)] rounded-sm"
+              disabled={schemaValidation.status === "error"}
+              title={
+                schemaValidation.status === "error"
+                  ? "Fix the schema error before switching format"
+                  : "Schema format"
+              }
+              className={`h-[26px] min-w-[60px] px-1 flex-shrink-0 text-sm outline-none border border-[var(--popup-border-color)] rounded-sm ${
+                schemaValidation.status === "error"
+                  ? "bg-[var(--bg-color)] text-[var(--text-color)] opacity-40 cursor-not-allowed"
+                  : "bg-[var(--bg-color)] text-[var(--text-color)] cursor-pointer"
+              }`}
             >
               <option value="json">JSON</option>
               <option value="yaml">YAML</option>

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -59,21 +59,23 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     });
   };
 
-  const changeSchemaFormat = useCallback(
+const changeSchemaFormat = useCallback(
     (format: SchemaFormat) => {
-      sessionStorage.setItem(SESSION_FORMAT_KEY, format);
-      setSchemaFormat(format);
       if (format === schemaFormat) return;
       try {
+        let convertedText: string;
         if (format === "yaml") {
           const parsed = JSON.parse(schemaText);
-          setSchemaText(YAML.dump(parsed));
+          convertedText = YAML.dump(parsed);
         } else {
           const parsed = YAML.load(schemaText) as object;
-          setSchemaText(JSON.stringify(parsed, null, 2));
+          convertedText = JSON.stringify(parsed, null, 2);
         }
+        setSchemaText(convertedText);
+        setSchemaFormat(format);
+        sessionStorage.setItem(SESSION_FORMAT_KEY, format);
       } catch {
-        // If conversion fails, keep existing text as-is
+        // Schema has an error, so don't switch format, keep everything as it is
       }
     },
     [schemaFormat, schemaText]


### PR DESCRIPTION
## Summary

Fixes a bug where switching the schema format (JSON ↔ YAML) could leave schemaFormat and schemaText out of sync, corrupting the schema state. changeSchemaFormat now only commits the format switch after a successful conversion between JSON and YAML, ensuring the two values can never disagree. Additionally, the format dropdown is now disabled (with an explanatory tooltip) whenever the schema currently has a validation error, preventing format switches on invalid schema state in the first place.

## What kind of change does this PR introduce

Bug fix

## Screenshots/Video

https://github.com/user-attachments/assets/e3c1771c-65ca-4adf-92e8-62606ca92e1e

## Does this PR introduce a breaking change?

No

## If relevant, did you update the documentation?

No